### PR TITLE
chore: Improve stack diffing tools

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,4 +3,8 @@ import { App } from "@aws-cdk/core";
 import { CdkPlayground } from "../lib/cdk-playground";
 
 const app = new App();
-new CdkPlayground(app, "CdkPlayground", { stack: "deploy" });
+
+new CdkPlayground(app, "CdkPlayground", {
+  stack: "deploy",
+  stackName: "cdk-playground-PROD",
+});

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,8 +1,5 @@
 {
   "app": "npx ts-node bin/cdk.ts",
-  "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true"
-  }
+  "versionReporting": false,
+  "profile": "deployTools"
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -10,7 +10,9 @@
     "watch": "tsc -w",
     "test": "jest",
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
-    "synth": "cdk synth --path-metadata false --version-reporting false",
+    "synth": "cdk synth --path-metadata false",
+    "diff": "cdk diff --path-metadata false",
+    "deploy": "cdk deploy --path-metadata false",
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
     "start": "jest --watch"
   },


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds scripts to easily diff and deploy a CDK stack.

Annoyingly `path-metadata` cannot be set in `cdk.json`, so use the argument. I think this is a [bug](https://cdk-dev.slack.com/archives/C018XT6REKT/p1619640484046800).

Finally, by setting the `stackName` explicitly, we can do useful stuff like this:

```sh
npx cdk diff -path-metadata false cdk-playground-PROD
```

Or, using the alias:

```sh
npm run diff cdk-playground-PROD
```

See:
  - https://cdk-dev.slack.com/archives/C018XT6REKT/p1619640484046800
  - https://www.youtube.com/watch?v=bTC8XV5aLTo

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Checkout branch
- `cd cdk`
- `npm i`
- Get Janus credentials for `deployTools`
- Run `npm run diff cdk-playground-PROD` and observe output

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Interacting with real stacks becomes easier.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

n/a

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
