### PR TITLE
chore: Switch to GHA for CI 🎉 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,26 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          printenv
-          cat ${GITHUB_EVENT_PATH}
+      - uses: guardian/actions-assume-aws-role@v1.0.0
+        with:
+          awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+
+      # Node is needed for CDK
+      - name: Setup node
+        uses: guardian/actions-setup-node@v2.4.1
+        with:
+          cache: 'npm'
+          cache-dependency-path: 'cdk/package-lock.json'
+
+      # Java is needed for the Scala Play app
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - run: ./script/ci

--- a/README.md
+++ b/README.md
@@ -16,5 +16,4 @@ There are a couple of helpful scripts in the [script](./script) directory:
   1. `./script/switch-cdk` to install GuCDK from a GitHub branch. This is useful to test changes _without_ publishing to NPM first.
 
 ## Deploying
-The app is set up in the usual way, with [CI](https://teamcity.gutools.co.uk/buildConfiguration/Tools_CdkPlayground) on each branch
-and [CD](https://riffraff.gutools.co.uk/deployment/history?projectName=tools%3A%3Acdk-playground&stage=PROD&pageSize=20&page=1) on `main`.
+The app is set up in the usual way, with CI on each branch (via GitHub Actions) and [CD](https://riffraff.gutools.co.uk/deployment/history?projectName=devx%3A%3Acdk-playground&stage=PROD&pageSize=20&page=1) on `main`.

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ lazy val root = (project in file("."))
       s"-J-Dlogs.home=/var/log/${packageName.value}",
       s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
     ),
+    riffRaffPackageName := s"devx::${name.value}",
+    riffRaffManifestProjectName := riffRaffPackageName.value,
     riffRaffArtifactResources := Seq(
       (packageBin in Debian).value -> s"${name.value}/${name.value}.deb",
       baseDirectory.value / "riff-raff.yaml" -> "riff-raff.yaml",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.12")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts Artifact("jdeb", "jar", "jar")

--- a/script/ci
+++ b/script/ci
@@ -2,29 +2,17 @@
 
 set -e
 
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-ROOT_DIR=$DIR/..
+if [[ ! -z "${TEAMCITY_VERSION}" ]]; then
+  echo "Running in TeamCity. Don't build anything!"
+  exit 0
+fi
 
-setupNvm() {
-  export NVM_DIR="$HOME/.nvm"
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-
-  nvm install
-  nvm use
-}
-
-synthCdk() {
-  setupNvm
-
-  pushd $ROOT_DIR/cdk
-
+(
+  cd cdk
   npm ci
   npm run lint
   npm run test
   npm run synth
+)
 
-  popd
-}
-
-synthCdk
 sbt clean compile test riffRaffUpload

--- a/script/ci
+++ b/script/ci
@@ -27,4 +27,4 @@ synthCdk() {
 }
 
 synthCdk
-sbt clean compile test riffRaffNotifyTeamcity
+sbt clean compile test riffRaffUpload

--- a/script/ci
+++ b/script/ci
@@ -2,11 +2,6 @@
 
 set -e
 
-if [[ ! -z "${TEAMCITY_VERSION}" ]]; then
-  echo "Running in TeamCity. Don't build anything!"
-  exit 0
-fi
-
 (
   cd cdk
   npm ci


### PR DESCRIPTION
## What does this change?

Moves CI to GitHub Actions with the help of https://github.com/guardian/actions-assume-aws-role.

Here's a table of reasons:

| GitHub Actions                                                                     | TeamCity                                                                                                         |
|------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
| ✅ Build configuration is entirely tracked in VCS                                   | ❌ Build configuration is mostly done through UI                                                                  |
| ✅ No build queue                                                                   | ❌ Maximum 10 projects built in parallel, builds 11+ are queued, blocked until another finishes                   |
| ✅ Build logs are co-located with PRs and are easy to get to (see the “Checks” tab) | ❌ Build logs require logging into TeamCity (requires VPN)                                                        |
| ✅ A comprehensive default environment, including support for macOS builds          | ❌ Requires annoying dance to get nvm to work. ❌ Yarn is often globally installed! ❌ All builds must run on Linux |
| ✅ Free for public repositories (private repositories are paid)                     | ❌ We run and maintain our own TeamCity servers                                                                   |
| 🆗 Caching implemented per repository                                               | 🆗 Caching provided by a self-hosted instance of Nexus                                                            |

More detail [here](https://docs.google.com/document/d/1Xz-gzptICIza0oio0Kza3LWg2a6n_015o0MPu0LGfuU/edit#).

## How to test

A new Riff-Raff project (`devx::cdk-playground`) should be available to deploy and should [successfully deploy to PROD](https://riffraff.gutools.co.uk/deployment/view/1a07c6bc-b404-4e9b-8376-f5ec31688357).