### PR TITLE
ci: Use GHA provided by GuCDK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,7 @@ jobs:
         with:
           awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
-      # Node is needed for CDK
-      - name: Setup node
-        uses: guardian/actions-setup-node@v2.4.1
-        with:
-          cache: 'npm'
-          cache-dependency-path: 'cdk/package-lock.json'
+      - uses: guardian/cdk@aa-composite-action
 
       # Java is needed for the Scala Play app
       - name: Set up JDK 8

--- a/script/ci
+++ b/script/ci
@@ -2,12 +2,4 @@
 
 set -e
 
-(
-  cd cdk
-  npm ci
-  npm run lint
-  npm run test
-  npm run synth
-)
-
 sbt clean compile test riffRaffUpload


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This replaces the portion of CI for CDK with a composite action provided by the guardian/cdk repository in https://github.com/guardian/cdk/pull/871.

The impact is a reduction of boilerplate.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

CI should continue to work as before. That is, an artifact should be available to Riff-Raff to deploy and the artifact should contain a JSON CloudFormation template generated from CDK.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Less boilerplate.
