### PR TITLE
fix: Use correct instance type

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -6,13 +6,13 @@ Object {
     "cdkplayground": Object {
       "CODE": Object {
         "domainName": "IGNORED. Just here to satisfy the type checks.",
-        "maxInstances": 2,
-        "minInstances": 1,
+        "maxInstances": 0,
+        "minInstances": 0,
       },
       "PROD": Object {
         "domainName": "cdk-playground.devx.dev-gutools.co.uk",
-        "maxInstances": 6,
-        "minInstances": 3,
+        "maxInstances": 2,
+        "minInstances": 1,
       },
     },
   },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -168,7 +168,7 @@ Object {
         "ImageId": Object {
           "Ref": "AMICdkplayground",
         },
-        "InstanceType": "t3.small",
+        "InstanceType": "t4g.micro",
         "SecurityGroups": Array [
           Object {
             "Fn::GetAtt": Array [

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -22,7 +22,7 @@ export class CdkPlayground extends GuStack {
 
     new GuPlayApp(this, {
       app,
-      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
       access: { scope: AccessScope.PUBLIC },
       userData: {
         distributable: {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -40,6 +40,16 @@ export class CdkPlayground extends GuStack {
         },
       },
       monitoringConfiguration: { noMonitoring: true },
+      scaling: {
+        [Stage.CODE]: {
+          minimumInstances: 0,
+          maximumInstances: 0,
+        },
+        [Stage.PROD]: {
+          minimumInstances: 1,
+          maximumInstances: 2,
+        },
+      },
     });
   }
 }


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We want a Graviton instance - use a `t4g.micro` instance.

The change in #113 was faulty - I used the same instance type that was in the snapshot, which was the default of a parameter rather than an actual value. The actual value used in the deployed stack is `t4g.micro`.

This change also down-scales our ASG to run 1 instance in PROD as cdk-playground isn't a production app.