### PR TITLE
Update sbt-riffraff-artifact

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts Artifact("jdeb", "jar", "jar")


### PR DESCRIPTION
## What does this change?
Update sbt-riffraff-artifact to avoid warnings from AWS SDK on sbt startup.
