### PR TITLE
chore: Check how AWS auto-names S3 buckets

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -779,6 +779,37 @@ dpkg -i /cdk-playground/cdk-playground.deb",
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "mybucket15D133BF": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
   },
 }
 `;

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -4,6 +4,7 @@ import { Stage } from "@guardian/cdk/lib/constants";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack, GuStringParameter } from "@guardian/cdk/lib/constructs/core";
 import { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
+import { GuS3Bucket } from "@guardian/cdk/lib/constructs/s3";
 import { AccessScope, GuPlayApp } from "@guardian/cdk/lib/patterns/ec2-app";
 
 export class CdkPlayground extends GuStack {
@@ -51,5 +52,7 @@ export class CdkPlayground extends GuStack {
         },
       },
     });
+
+    new GuS3Bucket(this, "my-bucket", {});
   }
 }


### PR DESCRIPTION
Checking how a bucket is named when the `BucketName` property isn't provided. This is to help [this Discussion](https://github.com/guardian/recommendations/discussions/74).