### PR TITLE
feat: Move to `INFRA` stage

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -2,20 +2,6 @@
 
 exports[`The Deploy stack matches the snapshot 1`] = `
 Object {
-  "Mappings": Object {
-    "cdkplayground": Object {
-      "CODE": Object {
-        "domainName": "IGNORED. Just here to satisfy the type checks.",
-        "maxInstances": 0,
-        "minInstances": 0,
-      },
-      "PROD": Object {
-        "domainName": "cdk-playground.devx.dev-gutools.co.uk",
-        "maxInstances": 2,
-        "minInstances": 1,
-      },
-    },
-  },
   "Outputs": Object {
     "LoadBalancerCdkplaygroundDnsName": Object {
       "Description": "DNS entry for LoadBalancerCdkplayground",
@@ -46,15 +32,6 @@ Object {
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "Stage": Object {
-      "AllowedValues": Array [
-        "CODE",
-        "PROD",
-      ],
-      "Default": "CODE",
-      "Description": "Stage name",
-      "Type": "String",
-    },
     "VpcId": Object {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within",
@@ -79,24 +56,8 @@ Object {
         "LaunchConfigurationName": Object {
           "Ref": "AutoScalingGroupCdkplaygroundLaunchConfigFAE27BB8",
         },
-        "MaxSize": Object {
-          "Fn::FindInMap": Array [
-            "cdkplayground",
-            Object {
-              "Ref": "Stage",
-            },
-            "maxInstances",
-          ],
-        },
-        "MinSize": Object {
-          "Fn::FindInMap": Array [
-            "cdkplayground",
-            Object {
-              "Ref": "Stage",
-            },
-            "minInstances",
-          ],
-        },
+        "MaxSize": "2",
+        "MinSize": "1",
         "Tags": Array [
           Object {
             "Key": "App",
@@ -131,9 +92,7 @@ Object {
           Object {
             "Key": "Stage",
             "PropagateAtLaunch": true,
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "TargetGroupARNs": Array [
@@ -194,11 +153,7 @@ aws s3 cp 's3://",
                 Object {
                   "Ref": "DistributionBucketName",
                 },
-                "/deploy/",
-                Object {
-                  "Ref": "Stage",
-                },
-                "/cdk-playground/cdk-playground.deb' '/cdk-playground/cdk-playground.deb'
+                "/deploy/INFRA/cdk-playground/cdk-playground.deb' '/cdk-playground/cdk-playground.deb'
 dpkg -i /cdk-playground/cdk-playground.deb",
               ],
             ],
@@ -210,15 +165,15 @@ dpkg -i /cdk-playground/cdk-playground.deb",
     "CertificateCdkplayground47FCF7D9": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {
-        "DomainName": Object {
-          "Fn::FindInMap": Array [
-            "cdkplayground",
-            Object {
-              "Ref": "Stage",
+        "DomainName": "cdk-playground.devx.dev-gutools.co.uk",
+        "DomainValidationOptions": Array [
+          Object {
+            "DomainName": "cdk-playground.devx.dev-gutools.co.uk",
+            "HostedZoneId": Object {
+              "Ref": "HostedZone",
             },
-            "domainName",
-          ],
-        },
+          },
+        ],
         "Tags": Array [
           Object {
             "Key": "App",
@@ -238,9 +193,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "ValidationMethod": "DNS",
@@ -289,11 +242,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
                     Object {
                       "Ref": "DistributionBucketName",
                     },
-                    "/deploy/",
-                    Object {
-                      "Ref": "Stage",
-                    },
-                    "/cdk-playground/*",
+                    "/deploy/INFRA/cdk-playground/*",
                   ],
                 ],
               },
@@ -341,9 +290,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -459,9 +406,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
       },
@@ -531,9 +476,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "Type": "application",
@@ -571,9 +514,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {
@@ -622,11 +563,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/",
-                    Object {
-                      "Ref": "Stage",
-                    },
-                    "/deploy/cdk-playground",
+                    ":parameter/INFRA/deploy/cdk-playground",
                   ],
                 ],
               },
@@ -649,11 +586,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
                     Object {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/",
-                    Object {
-                      "Ref": "Stage",
-                    },
-                    "/deploy/cdk-playground/*",
+                    ":parameter/INFRA/deploy/cdk-playground/*",
                   ],
                 ],
               },
@@ -734,9 +667,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "TargetGroupAttributes": Array [
@@ -795,9 +726,7 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           },
           Object {
             "Key": "Stage",
-            "Value": Object {
-              "Ref": "Stage",
-            },
+            "Value": "INFRA",
           },
         ],
         "VpcId": Object {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -1,12 +1,15 @@
 import { InstanceClass, InstanceSize, InstanceType } from "@aws-cdk/aws-ec2";
 import type { App } from "@aws-cdk/core";
-import { Stage } from "@guardian/cdk/lib/constants";
+import { StageForInfrastructure } from "@guardian/cdk/lib/constants";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
-import { GuStack, GuStringParameter } from "@guardian/cdk/lib/constructs/core";
+import {
+  GuStackForInfrastructure,
+  GuStringParameter,
+} from "@guardian/cdk/lib/constructs/core";
 import { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
 import { AccessScope, GuPlayApp } from "@guardian/cdk/lib/patterns/ec2-app";
 
-export class CdkPlayground extends GuStack {
+export class CdkPlayground extends GuStackForInfrastructure {
   private static app: AppIdentity = {
     app: "cdk-playground",
   };
@@ -31,23 +34,15 @@ export class CdkPlayground extends GuStack {
         },
       },
       certificateProps: {
-        [Stage.CODE]: {
-          domainName: "IGNORED. Just here to satisfy the type checks.",
-        },
-        [Stage.PROD]: {
+        [StageForInfrastructure]: {
           domainName: "cdk-playground.devx.dev-gutools.co.uk",
           hostedZoneId: hostedZoneIdParam.valueAsString,
         },
       },
       monitoringConfiguration: { noMonitoring: true },
       scaling: {
-        [Stage.CODE]: {
-          minimumInstances: 0,
-          maximumInstances: 0,
-        },
-        [Stage.PROD]: {
+        [StageForInfrastructure]: {
           minimumInstances: 1,
-          maximumInstances: 2,
         },
       },
     });


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

`cdk-playground` is a singleton stack - there is no `CODE` version. This change updates stage from `PROD` to `INFRA` as it is more obvious.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

IIUC unless the property is set in `riff-raff.yaml`, Riff-Raff discovers CFN stacks via tags. If it cannot find a stack, it will create it. In this change, Riff-Raff will attempt to find a CFN stack with `Stage=INFRA` and fail to find one. To stop Riff-Raff from creating a new stack, we'd need to manually update the value of the `Stage` tag on the CFN stack to `INFRA`.