### PR TITLE
Update CODEOWNERS to Ops team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/developer-experience
+* @guardian/devx-operations


### PR DESCRIPTION
## What does this change?
Uses a more specific team for CODEOWNERS to direct reviews to the appropriate place