### PR TITLE
Add support for CDK diffing

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,4 +3,10 @@ import { App } from "@aws-cdk/core";
 import { CdkPlayground } from "../lib/cdk-playground";
 
 const app = new App();
-new CdkPlayground(app, "CdkPlayground", { stack: "deploy" });
+new CdkPlayground(app, "CdkPlayground", {
+  stack: "deploy",
+  cloudFormationStackName: "cdk-playground-PROD",
+  env: {
+    region: "eu-west-1",
+  },
+});

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node bin/cdk.ts",
+  "profile": "deployTools",
   "context": {
     "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
     "synth": "cdk synth --path-metadata false --version-reporting false",
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
+    "diff": "cdk diff --path-metadata false --version-reporting false",
     "start": "jest --watch"
   },
   "devDependencies": {

--- a/script/diff-cdk
+++ b/script/diff-cdk
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR=$DIR/..
+
+(
+  cd $ROOT_DIR/cdk
+
+  npm run diff
+)


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

One can now run `./script/diff-cdk` (or `npm run diff`) to compare their local CDK stack with the running instance.

This is useful when testing changes and offers a shorter feedback loop vs. using the AWS web console.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Clone the branch
- Run the script
- Observe the output

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

I'm not sure how useful the bash script is, added it to keep in line with the repo.