### PR TITLE
Ship logs to Central ELK

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -11,7 +11,9 @@ class AppComponents(context: ApplicationLoader.Context)
     with AssetsComponents {
 
   private val disabledFilters: Set[EssentialFilter] = Set(allowedHostsFilter)
-  override def httpFilters: Seq[EssentialFilter] = super.httpFilters.filterNot(disabledFilters.contains)
+  override def httpFilters: Seq[EssentialFilter] = super.httpFilters.filterNot(disabledFilters.contains) ++ Seq(
+    new RequestLoggingFilter(materializer)
+  )
 
   lazy val managementController = new ManagementController(controllerComponents)
 

--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,9 +1,11 @@
 import play.api._
+import play.api.libs.logback.LogbackLoggerConfigurator
 
 class AppLoader extends ApplicationLoader {
   private var components: AppComponents = _
 
   def load(context: ApplicationLoader.Context): Application = {
+    new LogbackLoggerConfigurator().configure(context.environment)
     components = new AppComponents(context)
     components.application
   }

--- a/app/RequestLoggingFilter.scala
+++ b/app/RequestLoggingFilter.scala
@@ -1,0 +1,61 @@
+import akka.stream.Materializer
+import net.logstash.logback.marker.Markers.appendEntries
+import play.api.{Logging, MarkerContext}
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+import scala.jdk.CollectionConverters._
+
+class RequestLoggingFilter(override val mat: Materializer)(implicit ec: ExecutionContext) extends Filter with Logging {
+  override def apply(next: (RequestHeader) => Future[Result])(rh: RequestHeader): Future[Result] = {
+    val start = System.currentTimeMillis()
+    val result = next(rh)
+
+    result onComplete {
+      case Success(response) =>
+        val duration = System.currentTimeMillis() - start
+        logSuccess(rh, response, duration)
+
+      case Failure(err) =>
+        val duration = System.currentTimeMillis() - start
+        logFailure(rh, err, duration)
+    }
+
+    result
+  }
+
+  private def logSuccess(request: RequestHeader, response: Result, duration: Long): Unit = {
+    val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
+    val referer = request.headers.get("Referer").getOrElse("")
+    val length = response.header.headers.getOrElse("Content-Length", 0)
+
+    val mandatoryMarkers = Map(
+      "origin" -> originIp,
+      "referrer" -> referer,
+      "method" -> request.method,
+      "status" -> response.header.status,
+      "duration" -> duration
+    )
+
+    val markers = MarkerContext(appendEntries(mandatoryMarkers.asJava))
+    logger.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ${response.header.status} $length "$referer" ${duration}ms""")(markers)
+  }
+
+  private def logFailure(request: RequestHeader, throwable: Throwable, duration: Long): Unit = {
+    val originIp = request.headers.get("X-Forwarded-For").getOrElse(request.remoteAddress)
+    val referer = request.headers.get("Referer").getOrElse("")
+
+
+    val mandatoryMarkers = Map(
+      "origin" -> originIp,
+      "referrer" -> referer,
+      "method" -> request.method,
+      "duration" -> duration
+    )
+
+    val markers = MarkerContext(appendEntries(mandatoryMarkers.asJava))
+    logger.info(s"""$originIp - "${request.method} ${request.uri} ${request.version}" ERROR "$referer" ${duration}ms""")(markers)
+    logger.error(s"Error for ${request.method} ${request.uri}", throwable)
+  }
+}

--- a/app/controllers/ManagementController.scala
+++ b/app/controllers/ManagementController.scala
@@ -15,6 +15,7 @@ class ManagementController (override val controllerComponents: ControllerCompone
   }
 
   def healthCheck: Action[AnyContent] = Action {
+    logger.info("hello from the health check")
     Ok("OK")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,26 @@
 import com.gu.riffraff.artifact.BuildInfo
 
+// https://github.com/orgs/playframework/discussions/11222
+val jacksonVersion         = "2.13.2"
+val jacksonDatabindVersion = "2.13.2.2"
+
+val jacksonOverrides = Seq(
+  "com.fasterxml.jackson.core"     % "jackson-core",
+  "com.fasterxml.jackson.core"     % "jackson-annotations",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
+).map(_ % jacksonVersion)
+
+val jacksonDatabindOverrides = Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+)
+
+val akkaSerializationJacksonOverrides = Seq(
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
+  "com.fasterxml.jackson.module"     % "jackson-module-parameter-names",
+  "com.fasterxml.jackson.module"     %% "jackson-module-scala",
+).map(_ % jacksonVersion)
+
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, BuildInfoPlugin, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
   .settings(
@@ -18,6 +39,14 @@ lazy val root = (project in file("."))
       s"-J-Dlogs.home=/var/log/${packageName.value}",
       s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
     ),
+
+    libraryDependencies ++= jacksonDatabindOverrides
+      ++ jacksonOverrides
+      ++ akkaSerializationJacksonOverrides
+      ++ Seq(
+        "net.logstash.logback" % "logstash-logback-encoder" % "7.1.1"
+      ),
+
     riffRaffPackageName := s"devx::${name.value}",
     riffRaffManifestProjectName := riffRaffPackageName.value,
     riffRaffArtifactResources := Seq(

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -94,6 +94,11 @@ Object {
             "PropagateAtLaunch": true,
             "Value": "PROD",
           },
+          Object {
+            "Key": "SystemdUnit",
+            "PropagateAtLaunch": true,
+            "Value": "cdk-playground.service",
+          },
         ],
         "TargetGroupARNs": Array [
           Object {

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -80,6 +80,13 @@ Object {
             "Value": "guardian/cdk-playground",
           },
           Object {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          Object {
             "Key": "Name",
             "PropagateAtLaunch": true,
             "Value": "CdkPlayground/AutoScalingGroupCdkplayground",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -4,6 +4,7 @@ import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack, GuStringParameter } from "@guardian/cdk/lib/constructs/core";
 import { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
 import type { App } from "aws-cdk-lib";
+import { Tags } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType } from "aws-cdk-lib/aws-ec2";
 
 export class CdkPlayground extends GuStack {
@@ -20,7 +21,7 @@ export class CdkPlayground extends GuStack {
       description: "Route53 hosted zone",
     });
 
-    new GuPlayApp(this, {
+    const { autoScalingGroup } = new GuPlayApp(this, {
       app,
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
       access: { scope: AccessScope.PUBLIC },
@@ -40,5 +41,10 @@ export class CdkPlayground extends GuStack {
         maximumInstances: 2,
       },
     });
+
+    Tags.of(autoScalingGroup).add(
+      "SystemdUnit",
+      `${CdkPlayground.app.app}.service`
+    );
   }
 }

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,13 +11,13 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@guardian/cdk": "41.0.0",
+        "@guardian/cdk": "41.1.0",
         "@guardian/eslint-config-typescript": "^1.0.1",
         "@types/jest": "^27.4.1",
         "@types/node": "17.0.26",
         "aws-cdk": "2.20.0",
         "aws-cdk-lib": "2.20.0",
-        "constructs": "10.0.106",
+        "constructs": "10.0.110",
         "eslint": "^8.14.0",
         "jest": "^27.5.1",
         "prettier": "^2.6.2",
@@ -677,15 +677,17 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "41.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-41.0.0.tgz",
-      "integrity": "sha512-KtWmmrcqbdQijDNHHdtqExr3+RTKR9tnvhEg876hs0fiLYvZjQ27TQYYyXk7r50F/WvYiB42J15RlrY6pn0W0A==",
+      "version": "41.1.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-41.1.0.tgz",
+      "integrity": "sha512-/RCQLCKf+DFle2BVhtbbXbef8+XmsgRl1V8RAAMjCdkAKfk4YAoMoBg/Z9xLKr+HKdMDfsSJowLZZ6gwswKpwg==",
       "dev": true,
       "dependencies": {
-        "aws-sdk": "^2.1109.0",
+        "@oclif/core": "1.7.0",
+        "aws-cdk-lib": "2.20.0",
+        "aws-sdk": "^2.1113.0",
         "chalk": "^4.1.2",
-        "cli-ux": "^5.6.6",
         "codemaker": "^1.55.1",
+        "constructs": "10.0.110",
         "git-url-parse": "^11.6.0",
         "inquirer": "^8.2.2",
         "lodash.camelcase": "^4.3.0",
@@ -698,8 +700,9 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
+        "aws-cdk": "2.20.0",
         "aws-cdk-lib": "2.20.0",
-        "constructs": "10.0.106"
+        "constructs": "10.0.110"
       }
     },
     "node_modules/@guardian/eslint-config": {
@@ -1167,140 +1170,59 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@oclif/command": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
-      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
+    "node_modules/@oclif/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-I4q4qgtnNG7ef4sBDrJhwADdi7RExQV7LnflnXaWZZDiUoqF9AdOjC4jjx40MK0rRrCehCUtPNZBcr3WmxuS4Q==",
       "dev": true,
       "dependencies": {
-        "@oclif/config": "^1.18.2",
-        "@oclif/errors": "^1.3.5",
-        "@oclif/help": "^1.0.1",
-        "@oclif/parser": "^3.8.6",
-        "debug": "^4.1.1",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@oclif/config": "^1"
-      }
-    },
-    "node_modules/@oclif/config": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/errors": "^1.3.5",
-        "@oclif/parser": "^3.8.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-wsl": "^2.1.1",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/errors": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
-      "integrity": "sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^3.0.0",
-        "fs-extra": "^8.1",
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^3.0.2",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.10.0",
+        "debug": "^4.3.3",
+        "ejs": "^3.1.6",
+        "fs-extra": "^9.1.0",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
         "indent-string": "^4.0.0",
-        "strip-ansi": "^6.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "lodash": "^4.17.21",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.5",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "tslib": "^2.3.1",
+        "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
-    "node_modules/@oclif/errors/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+    "node_modules/@oclif/core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@oclif/errors/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@oclif/errors/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/@oclif/help": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
-      "integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/config": "1.18.2",
-        "@oclif/errors": "1.3.5",
-        "chalk": "^4.1.2",
-        "indent-string": "^4.0.0",
-        "lodash": "^4.17.21",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^6.2.0"
+        "node": ">=10"
       },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/help/node_modules/@oclif/config": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-      "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/errors": "^1.3.3",
-        "@oclif/parser": "^3.8.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-wsl": "^2.1.1",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@oclif/help/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@oclif/linewrap": {
@@ -1309,28 +1231,13 @@
       "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
       "dev": true
     },
-    "node_modules/@oclif/parser": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
-      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/errors": "^1.3.5",
-        "@oclif/linewrap": "^1.0.0",
-        "chalk": "^4.1.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@oclif/screen": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
+      "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==",
       "dev": true,
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -1880,6 +1787,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2114,9 +2027,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1111.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1111.0.tgz",
-      "integrity": "sha512-WRyNcCckzmu1djTAWfR2r+BuI/PbuLrhG3oa+oH39v4NZ4EecYWFL1CoCPlC2kRUML4maSba5T4zlxjcNl7ELQ==",
+      "version": "2.1129.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1129.0.tgz",
+      "integrity": "sha512-gQZaByfW7zKCg1n/kA+xDdLhI/SauaokRTq+lztK1cCCdFkR5CShcKeK/qUgVxjy43mwB7CkeTh1WUr2NMb0jg==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2503,12 +2416,12 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
-      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.0.tgz",
+      "integrity": "sha512-ug+V4/Qy3+0jX9XkWPV/AwHD98RxKXqDpL37vJBOxQhD90qQ3rDqDKoFpef9se91iTUuOXKlyg2HUyHBo5lHsQ==",
       "dev": true,
       "dependencies": {
-        "string-width": "^4.2.0"
+        "string-width": "^4.2.3"
       },
       "engines": {
         "node": ">=4"
@@ -2524,91 +2437,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-ux": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.7.tgz",
-      "integrity": "sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "dependencies": {
-        "@oclif/command": "^1.8.15",
-        "@oclif/errors": "^1.3.5",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.4.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/cli-ux/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/cli-ux/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/cli-ux/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/cli-ux/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/cli-width": {
@@ -2707,9 +2535,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.0.106",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.106.tgz",
-      "integrity": "sha512-6k8z7O3q6UigE62QW/z34YcSqa1elCDEGz1rTwaMkiVjdL93mB6YLNCpC21FYVUbx+rauTdsQCD3ejVxdAmazg==",
+      "version": "10.0.110",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.110.tgz",
+      "integrity": "sha512-Ojh53qbHi5XxkOFd7acUQebVzEn00KXF93YRwd5vii7tiVrkjgufWPl5NgdhNmvmC/lcQ1w8ke77PN37gQdgoQ==",
       "dev": true,
       "engines": {
         "node": ">= 12.7.0"
@@ -2938,6 +2766,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ejs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
+      "integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
+      "dev": true,
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3601,15 +3444,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/extract-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3714,6 +3548,36 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
+      "integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -4644,6 +4508,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/jest": {
@@ -8251,15 +8133,17 @@
       }
     },
     "@guardian/cdk": {
-      "version": "41.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-41.0.0.tgz",
-      "integrity": "sha512-KtWmmrcqbdQijDNHHdtqExr3+RTKR9tnvhEg876hs0fiLYvZjQ27TQYYyXk7r50F/WvYiB42J15RlrY6pn0W0A==",
+      "version": "41.1.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-41.1.0.tgz",
+      "integrity": "sha512-/RCQLCKf+DFle2BVhtbbXbef8+XmsgRl1V8RAAMjCdkAKfk4YAoMoBg/Z9xLKr+HKdMDfsSJowLZZ6gwswKpwg==",
       "dev": true,
       "requires": {
-        "aws-sdk": "^2.1109.0",
+        "@oclif/core": "1.7.0",
+        "aws-cdk-lib": "2.20.0",
+        "aws-sdk": "^2.1113.0",
         "chalk": "^4.1.2",
-        "cli-ux": "^5.6.6",
         "codemaker": "^1.55.1",
+        "constructs": "10.0.110",
         "git-url-parse": "^11.6.0",
         "inquirer": "^8.2.2",
         "lodash.camelcase": "^4.3.0",
@@ -8632,115 +8516,50 @@
         "fastq": "^1.6.0"
       }
     },
-    "@oclif/command": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.16.tgz",
-      "integrity": "sha512-rmVKYEsKzurfRU0xJz+iHelbi1LGlihIWZ7Qvmb/CBz1EkhL7nOkW4SVXmG2dA5Ce0si2gr88i6q4eBOMRNJ1w==",
+    "@oclif/core": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-I4q4qgtnNG7ef4sBDrJhwADdi7RExQV7LnflnXaWZZDiUoqF9AdOjC4jjx40MK0rRrCehCUtPNZBcr3WmxuS4Q==",
       "dev": true,
       "requires": {
-        "@oclif/config": "^1.18.2",
-        "@oclif/errors": "^1.3.5",
-        "@oclif/help": "^1.0.1",
-        "@oclif/parser": "^3.8.6",
-        "debug": "^4.1.1",
-        "semver": "^7.3.2"
-      }
-    },
-    "@oclif/config": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.3.tgz",
-      "integrity": "sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==",
-      "dev": true,
-      "requires": {
-        "@oclif/errors": "^1.3.5",
-        "@oclif/parser": "^3.8.0",
-        "debug": "^4.1.1",
-        "globby": "^11.0.1",
-        "is-wsl": "^2.1.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@oclif/errors": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.3.5.tgz",
-      "integrity": "sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^3.0.0",
-        "fs-extra": "^8.1",
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^3.0.2",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.10.0",
+        "debug": "^4.3.3",
+        "ejs": "^3.1.6",
+        "fs-extra": "^9.1.0",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
         "indent-string": "^4.0.0",
-        "strip-ansi": "^6.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "lodash": "^4.17.21",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.5",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "tslib": "^2.3.1",
+        "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
-    },
-    "@oclif/help": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@oclif/help/-/help-1.0.1.tgz",
-      "integrity": "sha512-8rsl4RHL5+vBUAKBL6PFI3mj58hjPCp2VYyXD4TAa7IMStikFfOH2gtWmqLzIlxAED2EpD0dfYwo9JJxYsH7Aw==",
-      "dev": true,
-      "requires": {
-        "@oclif/config": "1.18.2",
-        "@oclif/errors": "1.3.5",
-        "chalk": "^4.1.2",
-        "indent-string": "^4.0.0",
-        "lodash": "^4.17.21",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "dependencies": {
-        "@oclif/config": {
-          "version": "1.18.2",
-          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.18.2.tgz",
-          "integrity": "sha512-cE3qfHWv8hGRCP31j7fIS7BfCflm/BNZ2HNqHexH+fDrdF2f1D5S8VmXWLC77ffv3oDvWyvE9AZeR0RfmHCCaA==",
-          "dev": true,
-          "requires": {
-            "@oclif/errors": "^1.3.3",
-            "@oclif/parser": "^3.8.0",
-            "debug": "^4.1.1",
-            "globby": "^11.0.1",
-            "is-wsl": "^2.1.1",
-            "tslib": "^2.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -8751,22 +8570,10 @@
       "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
       "dev": true
     },
-    "@oclif/parser": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.7.tgz",
-      "integrity": "sha512-b11xBmIUK+LuuwVGJpFs4LwQN2xj2cBWj2c4z1FtiXGrJ85h9xV6q+k136Hw0tGg1jQoRXuvuBnqQ7es7vO9/Q==",
-      "dev": true,
-      "requires": {
-        "@oclif/errors": "^1.3.5",
-        "@oclif/linewrap": "^1.0.0",
-        "chalk": "^4.1.0",
-        "tslib": "^2.3.1"
-      }
-    },
     "@oclif/screen": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-1.0.4.tgz",
-      "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.2.tgz",
+      "integrity": "sha512-S/SF/XYJeevwIgHFmVDAFRUvM3m+OjhvCAYMk78ZJQCYCQ5wS7j+LTt1ZEv2jpEEGg2tx/F6TYYWxddNAYHrFQ==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -9184,6 +8991,12 @@
         "es-abstract": "^1.19.0"
       }
     },
+    "async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -9338,9 +9151,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1111.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1111.0.tgz",
-      "integrity": "sha512-WRyNcCckzmu1djTAWfR2r+BuI/PbuLrhG3oa+oH39v4NZ4EecYWFL1CoCPlC2kRUML4maSba5T4zlxjcNl7ELQ==",
+      "version": "2.1129.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1129.0.tgz",
+      "integrity": "sha512-gQZaByfW7zKCg1n/kA+xDdLhI/SauaokRTq+lztK1cCCdFkR5CShcKeK/qUgVxjy43mwB7CkeTh1WUr2NMb0jg==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -9624,12 +9437,12 @@
       }
     },
     "cli-progress": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
-      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.0.tgz",
+      "integrity": "sha512-ug+V4/Qy3+0jX9XkWPV/AwHD98RxKXqDpL37vJBOxQhD90qQ3rDqDKoFpef9se91iTUuOXKlyg2HUyHBo5lHsQ==",
       "dev": true,
       "requires": {
-        "string-width": "^4.2.0"
+        "string-width": "^4.2.3"
       }
     },
     "cli-spinners": {
@@ -9637,77 +9450,6 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
       "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "dev": true
-    },
-    "cli-ux": {
-      "version": "5.6.7",
-      "resolved": "https://registry.npmjs.org/cli-ux/-/cli-ux-5.6.7.tgz",
-      "integrity": "sha512-dsKAurMNyFDnO6X1TiiRNiVbL90XReLKcvIq4H777NMqXGBxBws23ag8ubCJE97vVZEgWG2eSUhsyLf63Jv8+g==",
-      "dev": true,
-      "requires": {
-        "@oclif/command": "^1.8.15",
-        "@oclif/errors": "^1.3.5",
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^1.0.4",
-        "ansi-escapes": "^4.3.0",
-        "ansi-styles": "^4.2.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "clean-stack": "^3.0.0",
-        "cli-progress": "^3.4.0",
-        "extract-stack": "^2.0.0",
-        "fs-extra": "^8.1",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.13.1",
-        "lodash": "^4.17.21",
-        "natural-orderby": "^2.0.1",
-        "object-treeify": "^1.1.4",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "supports-color": "^8.1.0",
-        "supports-hyperlinks": "^2.1.0",
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
-        }
-      }
     },
     "cli-width": {
       "version": "3.0.0",
@@ -9786,9 +9528,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.0.106",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.106.tgz",
-      "integrity": "sha512-6k8z7O3q6UigE62QW/z34YcSqa1elCDEGz1rTwaMkiVjdL93mB6YLNCpC21FYVUbx+rauTdsQCD3ejVxdAmazg==",
+      "version": "10.0.110",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.110.tgz",
+      "integrity": "sha512-Ojh53qbHi5XxkOFd7acUQebVzEn00KXF93YRwd5vii7tiVrkjgufWPl5NgdhNmvmC/lcQ1w8ke77PN37gQdgoQ==",
       "dev": true
     },
     "convert-source-map": {
@@ -9965,6 +9707,15 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "ejs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
+      "integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
+      "dev": true,
+      "requires": {
+        "jake": "^10.8.5"
       }
     },
     "electron-to-chromium": {
@@ -10465,12 +10216,6 @@
         "tmp": "^0.0.33"
       }
     },
-    "extract-stack": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-stack/-/extract-stack-2.0.0.tgz",
-      "integrity": "sha512-AEo4zm+TenK7zQorGK1f9mJ8L14hnTDi2ZQPR+Mub1NX8zimka1mXpV5LpH8x9HoUmFSHZCfLHqWvp0Y4FxxzQ==",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10561,6 +10306,35 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "filelist": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.3.tgz",
+      "integrity": "sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -11230,6 +11004,18 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jake": {
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.1",
+        "minimatch": "^3.0.4"
       }
     },
     "jest": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,13 +15,13 @@
     "start": "jest --watch"
   },
   "devDependencies": {
+    "@guardian/cdk": "41.1.0",
     "@guardian/eslint-config-typescript": "^1.0.1",
-    "@guardian/cdk": "41.0.0",
     "@types/jest": "^27.4.1",
     "@types/node": "17.0.26",
     "aws-cdk": "2.20.0",
     "aws-cdk-lib": "2.20.0",
-    "constructs": "10.0.106",
+    "constructs": "10.0.110",
     "eslint": "^8.14.0",
     "jest": "^27.5.1",
     "prettier": "^2.6.2",

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -11,9 +11,7 @@
   </appender>
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
-    </encoder>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
   </appender>
 
   <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -24,18 +24,7 @@
     <appender-ref ref="STDOUT" />
   </appender>
 
-  <logger name="play" level="INFO" />
-  <logger name="application" level="DEBUG" />
-
-  <logger name="play.core" level="ERROR"/>
-
-  <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
-  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
-  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
-  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
-
-  <root level="WARN">
+  <root level="INFO">
     <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.7
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
Easiest reviewed commit by commit.

## What does this change?

In this change we configure application log shipping to Central ELK using https://github.com/guardian/devx-logs 🎉 .

There are a couple of prerequisites to enable this:
  -  `@guardian/cdk` must be on v41.1.0 ([release notes](https://github.com/guardian/cdk/releases/tag/v41.1.0))
  - The ASG must have a `SystemdUnit` tag (to be done by GuCDK in future, as described [here](https://github.com/guardian/amiable/pull/127))

`cdk-playground` doesn't actually produce any logs, so in this change a request logging filter has been added (https://github.com/guardian/cdk-playground/pull/198/commits/56e6daa575ec16ab83fc90c78e3ac4cd4c28947b).

It's worth noting that logging was not [configured correctly](https://www.playframework.com/documentation/2.8.x/SettingsLogger#Using-a-custom-application-loader) for a Play app that uses a custom application loader, so this has been fixed (https://github.com/guardian/cdk-playground/pull/198/commits/6e5b877693f86d97785971ac4c6c8706d74b2ff4).

Lastly, logs to the console have been swapped to use the `LogstashEncoder`, to make them easier to process downstream. Alas, downstream processes are treating log lines as text at the moment, so we're not getting markers in Central ELK.

## How to test

[View the logs in Central ELK?](https://logs.gutools.co.uk/s/devx/goto/317d1240-cd2f-11ec-998f-373d9785faa5)