### PR TITLE
wip: set stage marker to test fluentbit's priorities

### DIFF
--- a/app/RequestLoggingFilter.scala
+++ b/app/RequestLoggingFilter.scala
@@ -35,7 +35,8 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
       "referrer" -> referer,
       "method" -> request.method,
       "status" -> response.header.status,
-      "duration" -> duration
+      "duration" -> duration,
+      "stage" -> "monkey"
     )
 
     val markers = MarkerContext(appendEntries(mandatoryMarkers.asJava))


### PR DESCRIPTION
There is a question about what happens when both the application and Fluentbit creates a marker - there can only be one in ELK, so which wins.

In this change, we set `stage` to be `monkey` in the application. Fluentbit sets `stage` from the instance tags (`PROD` in this case).

❓  If we see logs in ELK with stage `monkey` then we know Fluentbit is not replacing existing fields.
❓  If we see logs in ELK with stage `PROD` then we know Fluentbit is overwriting fields.

✅  We're seeing logs in ELK with stage `monkey`!
![image](https://user-images.githubusercontent.com/836140/167168193-0a9bb7b7-bc53-4c25-9cc5-86e2874e841e.png)

This also means that any timestamps in ELK represent the timestamps from the application logs, and not Fluentbit's 🎉 .