### PR TITLE
feat: Log an additional marker with a timestamp

### DIFF
--- a/app/RequestLoggingFilter.scala
+++ b/app/RequestLoggingFilter.scala
@@ -3,6 +3,8 @@ import net.logstash.logback.marker.Markers.appendEntries
 import play.api.{Logging, MarkerContext}
 import play.api.mvc.{Filter, RequestHeader, Result}
 
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 import scala.jdk.CollectionConverters._
@@ -35,7 +37,8 @@ class RequestLoggingFilter(override val mat: Materializer)(implicit ec: Executio
       "referrer" -> referer,
       "method" -> request.method,
       "status" -> response.header.status,
-      "duration" -> duration
+      "duration" -> duration,
+      "applicationTimestamp" -> OffsetDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
     )
 
     val markers = MarkerContext(appendEntries(mandatoryMarkers.asJava))


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Following https://github.com/guardian/cdk-playground/pull/199#issuecomment-1120789638, this adds a new marker to log lines to help determine the source of the `@timstamp` in ELK when using fluentbit:
  - Time of `logger.info` being called by application
  - Time of Fluentbit's ingestion of application logs
  - Time of logstash processing Kinesis message
  - Time of document being written to elasticsearch

Whichever matches `applicationTimestamp` (though likely off by a fraction of a second), is the source.