### PR TITLE
Add PROD as the only allowed stage

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -2,6 +2,8 @@ stacks:
   - deploy
 regions:
   - eu-west-1
+allowedStages:
+  - PROD
 deployments:
   cloudformation:
     type: cloud-formation


### PR DESCRIPTION
[We only deploy this project to `PROD`.](https://riffraff.gutools.co.uk/deployment/history?projectName=devx%3A%3Acdk-playground&page=1)