### PR TITLE
cause havoc?

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,7 +9,8 @@ deployments:
     type: cloud-formation
     app: cdk-playground
     parameters:
-      templatePath: CdkPlayground.template.json
+      templateStagePaths:
+        CODE: CdkPlayground.template.json
       amiParameter: AMICdkplayground
       amiEncrypted: true
       amiTags:


### PR DESCRIPTION
Just testing Riff-Raff's behaviour when `allowedStages` and `templateStagePaths` do not align.

It looks like [Riff-Raff](https://riffraff.gutools.co.uk/deployment/view/0b78fc90-21ed-4699-a00e-f9bcb1f898aa?verbose=0) has a default path it looks on for a CFN template when it's unable to locate it in `riff-raff.yaml`.