### PR TITLE
ci: Switch to guardian/actions-riff-raff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,3 +32,15 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - run: ./script/ci
+
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: devx::cdk-playground
+          configPath: cdk/cdk.out/riff-raff.yaml
+          contentDirectories: |
+            cdk.out:
+              - cdk/cdk.out
+            cdk-playground:
+              - target/cdk-playground.deb
+            cdk-playground-lambda:
+              - lambda/cdk-playground-lambda.zip

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts Artifact("jdeb", "jar", "jar")

--- a/script/ci
+++ b/script/ci
@@ -15,4 +15,7 @@ set -e
   zip cdk-playground-lambda.zip handler.js
 )
 
-sbt clean compile test riffRaffUpload
+sbt clean compile test debian:packageBin
+
+# `sbt debian:packageBin` produces `target/cdk-playground_1.0-SNAPSHOT_all.deb`. Rename it to something easier.
+mv target/cdk-playground_1.0-SNAPSHOT_all.deb target/cdk-playground.deb


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Switches to using `guardian/actions-riff-raff`, testing https://github.com/guardian/actions-riff-raff/pull/18. This allows us to remove the `sbt-riffraff-artifact` plugin, making our application code ignorant of Riff-Raff settings - these are pushed to CI.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

We should be able to deploy as normal.
