### PR TITLE
wip: Encrypted AMI via `amiParametersToTags`

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -44,6 +44,7 @@ deployments:
           BuiltBy: amigo
           AmigoStage: PROD
           Recipe: arm64-bionic-java11-deploy-infrastructure
+          Encrypted: "true"
     dependencies:
       - lambda-upload-eu-west-1-playground-cdk-playground-lambda
       - asg-upload-eu-west-1-playground-cdk-playground


### PR DESCRIPTION
This is a test to aid the testing of https://github.com/guardian/riff-raff/pull/991.