### PR TITLE
Remove Snyk schedule

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,8 +4,6 @@
 name: Snyk
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this change?

An explicit schedule is not needed; `snyk monitor` already sets up a schedule, and running on push to main is sufficient to always scan the latest version of the code.

At the start of our Snyk adoption push, we set up some repositories with schedules. As it turns out, GitHub disable scheduled workflows (on public repos) from running after 60 days of inactivity. This even seems to affect the other triggers of the workflow!

See: https://trello.com/c/XsBEwUnr.
