### PR TITLE
chore: Use updated AMIgo recipe

### DIFF
--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -43,7 +43,7 @@ export class CdkPlayground extends GuStack {
 				minimumInstances: 1,
 				maximumInstances: 2,
 			},
-			imageRecipe: 'arm64-bionic-java11-deploy-infrastructure',
+			imageRecipe: 'developerPlayground-arm64-java11',
 		});
 
 		// Get devx-logs to ship EC2 application logs to Central ELK


### PR DESCRIPTION
## What does this change?
The previous recipe was designed to be used by DevX services, and thus any changes with it might not have been tested on this service.

We've now got a dedicated recipe, which includes:
  - Ubuntu Jammy
  - Java 11 Corretto
  - CDK Base

## How to test
Deploy it, it should succeed.