### PR TITLE
test: Use rk/use-launch-templates branch to test https://github.com/guardian/cdk/pull/1731

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -18,8 +18,8 @@ Object {
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -99,8 +99,16 @@ Object {
       "Properties": Object {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": Object {
-          "Ref": "AutoScalingGroupCdkplaygroundLaunchConfigFAE27BB8",
+        "LaunchTemplate": Object {
+          "LaunchTemplateId": Object {
+            "Ref": "playgroundPRODcdkplayground7B64111F",
+          },
+          "Version": Object {
+            "Fn::GetAtt": Array [
+              "playgroundPRODcdkplayground7B64111F",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -128,11 +136,6 @@ Object {
             },
           },
           Object {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "CdkPlayground/AutoScalingGroupCdkplayground",
-          },
-          Object {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "playground",
@@ -158,65 +161,6 @@ Object {
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupCdkplaygroundInstanceProfileE118C4BB": Object {
-      "Properties": Object {
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupCdkplaygroundLaunchConfigFAE27BB8": Object {
-      "DependsOn": Array [
-        "InstanceRoleCdkplaygroundC280027A",
-      ],
-      "Properties": Object {
-        "IamInstanceProfile": Object {
-          "Ref": "AutoScalingGroupCdkplaygroundInstanceProfileE118C4BB",
-        },
-        "ImageId": Object {
-          "Ref": "AMICdkplayground",
-        },
-        "InstanceType": "t4g.micro",
-        "MetadataOptions": Object {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": Array [
-          Object {
-            "Fn::GetAtt": Array [
-              "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
-              "GroupId",
-            ],
-          },
-          Object {
-            "Fn::GetAtt": Array [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": Object {
-          "Fn::Base64": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "#!/bin/bash
-mkdir -p $(dirname '/cdk-playground/cdk-playground.deb')
-aws s3 cp 's3://",
-                Object {
-                  "Ref": "DistributionBucketName",
-                },
-                "/playground/PROD/cdk-playground/cdk-playground.deb' '/cdk-playground/cdk-playground.deb'
-dpkg -i /cdk-playground/cdk-playground.deb",
-              ],
-            ],
-          },
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateCdkplayground47FCF7D9": Object {
       "DeletionPolicy": "Retain",
@@ -665,6 +609,27 @@ dpkg -i /cdk-playground/cdk-playground.deb",
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundWazuhSecurityGroupBE1C2E039000E0905CDC": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ParameterStoreReadCdkplaygroundF78958B9": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -807,6 +772,27 @@ dpkg -i /cdk-playground/cdk-playground.deb",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupfromCdkPlaygroundLoadBalancerCdkplaygroundSecurityGroupE52E5B3890001018F1AF": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "lambda8B5974B5": Object {
       "DependsOn": Array [
@@ -1437,6 +1423,148 @@ dpkg -i /cdk-playground/cdk-playground.deb",
         },
       },
       "Type": "AWS::ApiGateway::Resource",
+    },
+    "playgroundPRODcdkplayground7B64111F": Object {
+      "Properties": Object {
+        "LaunchTemplateData": Object {
+          "IamInstanceProfile": Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "playgroundPRODcdkplaygroundProfile617BB4EE",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": Object {
+            "Ref": "AMICdkplayground",
+          },
+          "InstanceType": "t4g.micro",
+          "MetadataOptions": Object {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
+                "GroupId",
+              ],
+            },
+            Object {
+              "Fn::GetAtt": Array [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": Array [
+            Object {
+              "ResourceType": "instance",
+              "Tags": Array [
+                Object {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                Object {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk-playground",
+                },
+                Object {
+                  "Key": "Name",
+                  "Value": "CdkPlayground/playground-PROD-cdk-playground",
+                },
+                Object {
+                  "Key": "Stack",
+                  "Value": "playground",
+                },
+                Object {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+            Object {
+              "ResourceType": "volume",
+              "Tags": Array [
+                Object {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                Object {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk-playground",
+                },
+                Object {
+                  "Key": "Name",
+                  "Value": "CdkPlayground/playground-PROD-cdk-playground",
+                },
+                Object {
+                  "Key": "Stack",
+                  "Value": "playground",
+                },
+                Object {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+          ],
+          "UserData": Object {
+            "Fn::Base64": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "#!/bin/bash
+mkdir -p $(dirname '/cdk-playground/cdk-playground.deb')
+aws s3 cp 's3://",
+                  Object {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/playground/PROD/cdk-playground/cdk-playground.deb' '/cdk-playground/cdk-playground.deb'
+dpkg -i /cdk-playground/cdk-playground.deb",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": Array [
+          Object {
+            "ResourceType": "launch-template",
+            "Tags": Array [
+              Object {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              Object {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk-playground",
+              },
+              Object {
+                "Key": "Name",
+                "Value": "CdkPlayground/playground-PROD-cdk-playground",
+              },
+              Object {
+                "Key": "Stack",
+                "Value": "playground",
+              },
+              Object {
+                "Key": "Stage",
+                "Value": "PROD",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "playgroundPRODcdkplaygroundProfile617BB4EE": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "49.3.0",
+        "@guardian/cdk": "github:guardian/cdk#rk/use-launch-templates",
         "@guardian/eslint-config-typescript": "4.0.0",
         "@guardian/prettier": "3.0.0",
         "@types/jest": "^28.1.6",
@@ -698,9 +698,8 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "49.3.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.3.0.tgz",
-      "integrity": "sha512-VUs9YmlXUk3oQMWPJPMEtV/4bO1/8PU/eGvlfTaA+Aj6TmtH4OLnA5KdeeFAd47+8CYqz98dGK4OVtTtiQIe8A==",
+      "version": "49.2.1",
+      "resolved": "git+ssh://git@github.com/guardian/cdk.git#ac0980356c2465c386f8bfe0fd1d5e0d0be2ec7d",
       "dev": true,
       "dependencies": {
         "@oclif/core": "1.24.2",
@@ -5918,6 +5917,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7670,10 +7670,9 @@
       }
     },
     "@guardian/cdk": {
-      "version": "49.3.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.3.0.tgz",
-      "integrity": "sha512-VUs9YmlXUk3oQMWPJPMEtV/4bO1/8PU/eGvlfTaA+Aj6TmtH4OLnA5KdeeFAd47+8CYqz98dGK4OVtTtiQIe8A==",
+      "version": "git+ssh://git@github.com/guardian/cdk.git#ac0980356c2465c386f8bfe0fd1d5e0d0be2ec7d",
       "dev": true,
+      "from": "@guardian/cdk@github:guardian/cdk#rk/use-launch-templates",
       "requires": {
         "@oclif/core": "1.24.2",
         "aws-cdk-lib": "2.64.0",
@@ -11583,7 +11582,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "querystring": {
       "version": "0.2.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,7 +11,7 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "49.3.0",
+    "@guardian/cdk": "github:guardian/cdk#rk/use-launch-templates",
     "@guardian/eslint-config-typescript": "4.0.0",
     "@guardian/prettier": "3.0.0",
     "@types/jest": "^28.1.6",


### PR DESCRIPTION
## What does this change?

A real-world test of https://github.com/guardian/cdk/pull/1697.

## How to test

Deploy a build from this branch. It should [succeed](https://riffraff.gutools.co.uk/deployment/view/64e51d98-0681-4232-af67-59d544e19580), and the ASG should start using launch templates.

```json
{
  "name": "cdk-playground",
  "buildTime": 1677231301203,
  "branch": "rk/cdk-rk-use-launch-templates",
  "gitCommitId": "ba0f50eb410b5b70507d017428e1346bfbc0a201",
  "scalaVersion": "2.13.5",
  "version": "1.0-SNAPSHOT",
  "sbtVersion": "1.6.2",
  "buildNumber": "501"
}
```

### CloudFormation rollout

The update proceeds **without** recreating the ASG, and does not cause interruption of service.


