### PR TITLE
ci: Correct Java setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'corretto'
+          cache: 'sbt'
 
       # Build CDK and Play (in sequence)
       - run: ./script/ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,10 @@ jobs:
           cache-dependency-path: 'cdk/package-lock.json'
 
       # Java is needed for the Scala Play app
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: '11'
+          distribution: 'corretto'
 
       # Build CDK and Play (in sequence)
       - run: ./script/ci


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Update the version of Java used in CI to match that used in PROD (Java 11, corretto). Also cache sbt dependencies to improve build time.
