### PR TITLE
chore(deps): Bump @guardian/cdk from 49.4.0 to 49.4.1

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,14 +8,14 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "49.4.0",
+        "@guardian/cdk": "49.4.1",
         "@guardian/eslint-config-typescript": "5.0.0",
         "@guardian/prettier": "3.0.0",
         "@types/jest": "^28.1.6",
         "@types/node": "18.15.1",
-        "aws-cdk": "2.64.0",
-        "aws-cdk-lib": "2.64.0",
-        "constructs": "10.1.246",
+        "aws-cdk": "2.68.0",
+        "aws-cdk-lib": "2.68.0",
+        "constructs": "10.1.273",
         "jest": "^28.1.3",
         "source-map-support": "^0.5.20",
         "ts-jest": "^28.0.8",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.73",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.73.tgz",
-      "integrity": "sha512-zELCc24F0BKwDC1WkC1PGt+bsPAXp3ihHynjm3x932bZlhopp9of3kbEcR6/JxdrwCgw7GzYZ3Oi8mo7NiAJHw==",
+      "version": "2.2.106",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.106.tgz",
+      "integrity": "sha512-iZHFZJL7gdM2xw0qFqOww4eojxeyhHsaIuUgFrPo0vl7/0LhZzXBDJPnL5yGBWPWOs2tEaYvjkxYrpoLcpnCKg==",
       "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
@@ -49,9 +49,9 @@
       "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.62",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.62.tgz",
-      "integrity": "sha512-WYxEid/S+tb7ce/sxBvsY85uZt6vZMW0Bh4FP0e0oGY8O93ipsOJsAew+RLtOfO91GdIrZVr6ptXCxZgboPHZA==",
+      "version": "2.0.85",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.85.tgz",
+      "integrity": "sha512-o+k40Gw+h6MqzOe1eU3X+P3S9DAR1IPwxHKS999KQJNkvSGJHg5RVV1bW6EibQwA9ndqXvkym3LrXtIH9KP+Hg==",
       "dev": true
     },
     "node_modules/@babel/code-frame": {
@@ -698,17 +698,17 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "49.4.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
-      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
+      "version": "49.4.1",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.1.tgz",
+      "integrity": "sha512-wvIUMvMZgbw2hunfnT28WtK9j6AMaB9buOVcVAxBJX/JoxuQkQSMCGDI1A33KIc/AyVnVGLDtuIL/GPCSSLkuQ==",
       "dev": true,
       "dependencies": {
         "@oclif/core": "1.24.2",
-        "aws-cdk-lib": "2.64.0",
-        "aws-sdk": "^2.1315.0",
+        "aws-cdk-lib": "2.68.0",
+        "aws-sdk": "^2.1326.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.75.0",
-        "constructs": "10.1.246",
+        "codemaker": "^1.77.0",
+        "constructs": "10.1.273",
         "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
@@ -721,9 +721,9 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.64.0",
-        "aws-cdk-lib": "2.64.0",
-        "constructs": "10.1.246"
+        "aws-cdk": "2.68.0",
+        "aws-cdk-lib": "2.68.0",
+        "constructs": "10.1.273"
       }
     },
     "node_modules/@guardian/cdk/node_modules/argparse": {
@@ -1935,9 +1935,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.68.0.tgz",
+      "integrity": "sha512-r+C5M4J3C7RLiixhxsO/W9Kpb5iB0mFshyn5PXT1cGPkDbx23bnWLOab03jG7uHWIWI01DCipHQyTaeXXqvT3A==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1950,9 +1950,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz",
+      "integrity": "sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1966,9 +1966,9 @@
       ],
       "dev": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.52",
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
@@ -2156,9 +2156,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1318.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1318.0.tgz",
-      "integrity": "sha512-xRCKqx4XWXUIpjDCVHmdOSINEVCIC5+yhmgUGR9A6VfxfPs59HbxKyd5LB+CmXhVbwVUM4SRWG5O+agQj+w7Eg==",
+      "version": "2.1335.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1335.0.tgz",
+      "integrity": "sha512-cuX3OA9awP1rFEuemqNGF5278u4auFx7aS+C69d+QIwfH6cHE+hLxk660ypTIlionE40nGyYEjLhj6dZeHdWNw==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2545,9 +2545,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.75.0.tgz",
-      "integrity": "sha512-HGZQMJb+IXlGD5MJj6Ae2IXzkd4aoIufj/OfM0HxpJnldWx5rlzBjzgpI+YcK1RdaLm3HWMNDtTLti0qMsHtSA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.77.0.tgz",
+      "integrity": "sha512-XSHAqkXMn5OtcebJLVMFEW9puB+4ZmmChBFspEf62ZeYzs+ggSXEHW9GrjC/ZyX+sfxql6ciJP3z25sSp4VsVQ==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -2603,9 +2603,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.246",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
-      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
+      "version": "10.1.273",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.273.tgz",
+      "integrity": "sha512-JRaydmKm58aQm7crUcai3qGXtqhsh9e/dXyjQoZV6RiiEamf1V9A3yLLJIjit66Kl0Sub9quXgPmtqRfPYYlIg==",
       "dev": true,
       "engines": {
         "node": ">= 14.17.0"
@@ -5904,7 +5904,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7142,9 +7141,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.73",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.73.tgz",
-      "integrity": "sha512-zELCc24F0BKwDC1WkC1PGt+bsPAXp3ihHynjm3x932bZlhopp9of3kbEcR6/JxdrwCgw7GzYZ3Oi8mo7NiAJHw==",
+      "version": "2.2.106",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.106.tgz",
+      "integrity": "sha512-iZHFZJL7gdM2xw0qFqOww4eojxeyhHsaIuUgFrPo0vl7/0LhZzXBDJPnL5yGBWPWOs2tEaYvjkxYrpoLcpnCKg==",
       "dev": true
     },
     "@aws-cdk/asset-kubectl-v20": {
@@ -7154,9 +7153,9 @@
       "dev": true
     },
     "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.62",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.62.tgz",
-      "integrity": "sha512-WYxEid/S+tb7ce/sxBvsY85uZt6vZMW0Bh4FP0e0oGY8O93ipsOJsAew+RLtOfO91GdIrZVr6ptXCxZgboPHZA==",
+      "version": "2.0.85",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.85.tgz",
+      "integrity": "sha512-o+k40Gw+h6MqzOe1eU3X+P3S9DAR1IPwxHKS999KQJNkvSGJHg5RVV1bW6EibQwA9ndqXvkym3LrXtIH9KP+Hg==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -7657,17 +7656,17 @@
       }
     },
     "@guardian/cdk": {
-      "version": "49.4.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
-      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
+      "version": "49.4.1",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.1.tgz",
+      "integrity": "sha512-wvIUMvMZgbw2hunfnT28WtK9j6AMaB9buOVcVAxBJX/JoxuQkQSMCGDI1A33KIc/AyVnVGLDtuIL/GPCSSLkuQ==",
       "dev": true,
       "requires": {
         "@oclif/core": "1.24.2",
-        "aws-cdk-lib": "2.64.0",
-        "aws-sdk": "^2.1315.0",
+        "aws-cdk-lib": "2.68.0",
+        "aws-sdk": "^2.1326.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.75.0",
-        "constructs": "10.1.246",
+        "codemaker": "^1.77.0",
+        "constructs": "10.1.273",
         "git-url-parse": "^13.1.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
@@ -8600,23 +8599,23 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.68.0.tgz",
+      "integrity": "sha512-r+C5M4J3C7RLiixhxsO/W9Kpb5iB0mFshyn5PXT1cGPkDbx23bnWLOab03jG7uHWIWI01DCipHQyTaeXXqvT3A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz",
+      "integrity": "sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.52",
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
@@ -8744,9 +8743,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1318.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1318.0.tgz",
-      "integrity": "sha512-xRCKqx4XWXUIpjDCVHmdOSINEVCIC5+yhmgUGR9A6VfxfPs59HbxKyd5LB+CmXhVbwVUM4SRWG5O+agQj+w7Eg==",
+      "version": "2.1335.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1335.0.tgz",
+      "integrity": "sha512-cuX3OA9awP1rFEuemqNGF5278u4auFx7aS+C69d+QIwfH6cHE+hLxk660ypTIlionE40nGyYEjLhj6dZeHdWNw==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -9022,9 +9021,9 @@
       "dev": true
     },
     "codemaker": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.75.0.tgz",
-      "integrity": "sha512-HGZQMJb+IXlGD5MJj6Ae2IXzkd4aoIufj/OfM0HxpJnldWx5rlzBjzgpI+YcK1RdaLm3HWMNDtTLti0qMsHtSA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.77.0.tgz",
+      "integrity": "sha512-XSHAqkXMn5OtcebJLVMFEW9puB+4ZmmChBFspEf62ZeYzs+ggSXEHW9GrjC/ZyX+sfxql6ciJP3z25sSp4VsVQ==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -9073,9 +9072,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.246",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
-      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
+      "version": "10.1.273",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.273.tgz",
+      "integrity": "sha512-JRaydmKm58aQm7crUcai3qGXtqhsh9e/dXyjQoZV6RiiEamf1V9A3yLLJIjit66Kl0Sub9quXgPmtqRfPYYlIg==",
       "dev": true
     },
     "convert-source-map": {
@@ -11561,8 +11560,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,14 +11,14 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "49.4.0",
+    "@guardian/cdk": "49.4.1",
     "@guardian/eslint-config-typescript": "5.0.0",
     "@guardian/prettier": "3.0.0",
     "@types/jest": "^28.1.6",
     "@types/node": "18.15.1",
-    "aws-cdk": "2.64.0",
-    "aws-cdk-lib": "2.64.0",
-    "constructs": "10.1.246",
+    "aws-cdk": "2.68.0",
+    "aws-cdk-lib": "2.68.0",
+    "constructs": "10.1.273",
     "jest": "^28.1.3",
     "source-map-support": "^0.5.20",
     "ts-jest": "^28.0.8",


### PR DESCRIPTION
## What does this change?
Updates GuCDK to [49.4.1](https://github.com/guardian/cdk/releases/tag/v49.4.1).
