### PR TITLE
version bumps, remove libraries updated transitively

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,11 @@
 // https://github.com/orgs/playframework/discussions/11222
-val jacksonVersion         = "2.13.2"
-val jacksonDatabindVersion = "2.13.2.2"
+val jacksonVersion         = "2.14.2"
+val jacksonDatabindVersion = "2.14.2"
 
 val jacksonOverrides = Seq(
-  "com.fasterxml.jackson.core"     % "jackson-core",
-  "com.fasterxml.jackson.core"     % "jackson-annotations",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
 ).map(_ % jacksonVersion)
-
-val jacksonDatabindOverrides = Seq(
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
-)
 
 val akkaSerializationJacksonOverrides = Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
@@ -26,7 +20,7 @@ lazy val root = (project in file("."))
   .settings(
     name := """cdk-playground""",
     version := "1.0-SNAPSHOT",
-    scalaVersion := "2.13.5",
+    scalaVersion := "2.13.10",
     scalacOptions ++= List(
       "-encoding", "utf8",
       "-deprecation",
@@ -40,11 +34,10 @@ lazy val root = (project in file("."))
       s"-J-Xloggc:/var/log/${packageName.value}/gc.log",
     ),
 
-    libraryDependencies ++= jacksonDatabindOverrides
-      ++ jacksonOverrides
+    libraryDependencies ++= jacksonOverrides
       ++ akkaSerializationJacksonOverrides
       ++ Seq(
-        "net.logstash.logback" % "logstash-logback-encoder" % "7.1.1"
+        "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
       ),
 
     buildInfoKeys ++= Seq[BuildInfoKey](

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 // https://github.com/orgs/playframework/discussions/11222
 val jacksonVersion         = "2.14.2"
-val jacksonDatabindVersion = "2.14.2"
 
 val jacksonOverrides = Seq(
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.8" artifacts Artifact("jdeb", "jar", "jar")


### PR DESCRIPTION
## What does this change?

Fixes all high level vulnerabilities. simplifies build.sbt. bumps scala version. I'm also adding this to [scala-steward](https://github.com/guardian/scala-steward-public-repos/pull/37)

## How to test

run against snyk, confirm build still passes

## How can we measure success?

confirm there are no more high level vulnerabilities
