### PR TITLE
test: What happens if `amiParametersToTags` contains used config?

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: devx::cdk-playground
-          configPath: cdk/cdk.out/riff-raff.yaml
+          configPath: riff-raff.yaml
           contentDirectories: |
             cdk.out:
               - cdk/cdk.out

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,86 @@
+allowedStages:
+  - PROD
+deployments:
+  lambda-upload-eu-west-1-playground-cdk-playground-lambda:
+    type: aws-lambda
+    stacks:
+      - playground
+    regions:
+      - eu-west-1
+    app: cdk-playground-lambda
+    contentDirectory: cdk-playground-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: cdk-playground-lambda.zip
+    actions:
+      - uploadLambda
+  asg-upload-eu-west-1-playground-cdk-playground:
+    type: autoscaling
+    actions:
+      - uploadArtifacts
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    parameters:
+      bucketSsmLookup: true
+      prefixApp: true
+    contentDirectory: cdk-playground
+  cfn-eu-west-1-playground-cdk-playground:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        PROD: CdkPlayground.template.json
+      amiParametersToTags:
+        AMICdkplayground:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: developerPlayground-arm64-java11
+          Encrypted: 'true'
+        NotUsed:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: developerPlayground-arm64-java11
+          Encrypted: 'true'
+    dependencies:
+      - lambda-upload-eu-west-1-playground-cdk-playground-lambda
+      - asg-upload-eu-west-1-playground-cdk-playground
+  lambda-update-eu-west-1-playground-cdk-playground-lambda:
+    type: aws-lambda
+    stacks:
+      - playground
+    regions:
+      - eu-west-1
+    app: cdk-playground-lambda
+    contentDirectory: cdk-playground-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: cdk-playground-lambda.zip
+    actions:
+      - updateLambda
+    dependencies:
+      - cfn-eu-west-1-playground-cdk-playground
+  asg-update-eu-west-1-playground-cdk-playground:
+    type: autoscaling
+    actions:
+      - deploy
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    parameters:
+      bucketSsmLookup: true
+      prefixApp: true
+    dependencies:
+      - cfn-eu-west-1-playground-cdk-playground
+    contentDirectory: cdk-playground


### PR DESCRIPTION
Test to see what happens when `amiParametersToTags` includes an string that _not_ present as a parameter in the CloudFormation template.