### PR TITLE
Bump logback-classic to 1.2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= jacksonOverrides
       ++ akkaSerializationJacksonOverrides
       ++ Seq(
-        "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
+        "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
+        // Transient dependency of Play. No newer version of Play 2.9 or Play 3.0 with this vulnerability fixed.
+        "ch.qos.logback" % "logback-classic" % "1.2.13",
       ),
 
     buildInfoKeys ++= Seq[BuildInfoKey](


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps logback-classic to 1.2.13. Resolving 4 high vulnerabilities.