### PR TITLE
wip: Create subdomains via GuCname

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -27,6 +27,7 @@ Object {
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -231,6 +232,23 @@ Object {
       },
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
+    },
+    "DemoDNS": Object {
+      "Properties": Object {
+        "Name": "lambda.cdk-playground.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "lambdacdkplaygroundlambdaapidomainD1A8D46F",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "DescribeEC2PolicyFF5F9295": Object {
       "Properties": Object {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -88,5 +88,12 @@ export class CdkPlayground extends GuStack {
 			domainName: lambdaDomainName,
 			resourceRecord: domain.domainNameAliasDomainName,
 		});
+
+    new GuCname(this, 'DemoDNS', {
+      app: lambdaApp,
+      ttl: Duration.hours(1),
+      domainName: 'lambda.cdk-playground.gutools.co.uk',
+      resourceRecord: domain.domainNameAliasDomainName,
+    });
 	}
 }


### PR DESCRIPTION
Checking that (random) subdomains can be created via `GuCname`.

Once [deployed](https://riffraff.gutools.co.uk/deployment/view/4eeaa6c6-3204-446a-850c-586444b9bb8b), [https://lambda.cdk-playground.gutools.co.uk](https://lambda.cdk-playground.gutools.co.uk) should resolve (though will serve a certificate for `cdk-playground-lambda.gutools.co.uk` as this PR doesn't tweak the certificate attached to the API Gateway that's the origin for this record).

Once `main` is deployed, the DNS record will be removed again.

`dig` result, demonstrating the record was created:

```console
➜ dig lambda.cdk-playground.gutools.co.uk

; <<>> DiG 9.10.6 <<>> lambda.cdk-playground.gutools.co.uk
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 18067
;; flags: qr rd ra; QUERY: 1, ANSWER: 4, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;lambda.cdk-playground.gutools.co.uk. IN	A

;; ANSWER SECTION:
lambda.cdk-playground.gutools.co.uk. 3600 IN CNAME d-8aft3t6gvc.execute-api.eu-west-1.amazonaws.com.
d-8aft3t6gvc.execute-api.eu-west-1.amazonaws.com. 60 IN	A 52.210.221.239
d-8aft3t6gvc.execute-api.eu-west-1.amazonaws.com. 60 IN	A 34.240.242.137
d-8aft3t6gvc.execute-api.eu-west-1.amazonaws.com. 60 IN	A 34.249.54.28

;; Query time: 63 msec
;; SERVER: 192.168.50.1#53(192.168.50.1)
;; WHEN: Fri Dec 15 11:18:12 GMT 2023
;; MSG SIZE  rcvd: 342
```