### PR TITLE
feat: Introduce cdk-nag

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,6 +1,9 @@
 import 'source-map-support/register';
 import { GuRoot } from "@guardian/cdk/lib/constructs/root";
+import {Aspects} from "aws-cdk-lib";
+import { AwsSolutionsChecks } from 'cdk-nag'
 import { CdkPlayground } from '../lib/cdk-playground';
 
 const app = new GuRoot();
+Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
 new CdkPlayground(app, 'CdkPlayground');

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "20.11.16",
         "aws-cdk": "2.121.1",
         "aws-cdk-lib": "2.121.1",
+        "cdk-nag": "^2.28.29",
         "constructs": "10.3.0",
         "jest": "^28.1.3",
         "source-map-support": "^0.5.20",
@@ -2749,6 +2750,16 @@
       },
       "bin": {
         "cdl": "bin/cdl.js"
+      }
+    },
+    "node_modules/cdk-nag": {
+      "version": "2.28.29",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.29.tgz",
+      "integrity": "sha512-GmBFS1wKjiBoV1zkOtFyjtlpP7z/y+py/3cWi4QaTdx5bnYTE9REDGo8RdxBXStuNAyLhbjOPZXCY2w3QO0ntg==",
+      "dev": true,
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.116.0",
+        "constructs": "^10.0.5"
       }
     },
     "node_modules/chalk": {
@@ -6200,6 +6211,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -18,6 +18,7 @@
     "@types/node": "20.11.16",
     "aws-cdk": "2.121.1",
     "aws-cdk-lib": "2.121.1",
+    "cdk-nag": "^2.28.29",
     "constructs": "10.3.0",
     "jest": "^28.1.3",
     "source-map-support": "^0.5.20",


### PR DESCRIPTION
## What does this change?
Add [cdk-nag](https://aws.amazon.com/blogs/devops/manage-application-security-and-compliance-with-the-aws-cloud-development-kit-and-cdk-nag/) to check security compliance; any violations should fail the build.