### PR TITLE
Add a domain to be used in Fastly disaster recovery testing

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -24,6 +24,7 @@ Object {
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuCname",
+      "GuCname",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -261,6 +262,23 @@ Object {
     "EC2AppDNS": Object {
       "Properties": Object {
         "Name": "cdk-playground.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerCdkplayground7C6B4D97",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "FastlyDRTestDNS": Object {
+      "Properties": Object {
+        "Name": "cdk-status-resources.guim.co.uk",
         "RecordType": "CNAME",
         "ResourceRecords": Array [
           Object {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -24,6 +24,9 @@ export class CdkPlayground extends GuStack {
 
 		const ec2App = 'cdk-playground';
 		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
+    //New domain added for Fastly disaster recovery testing. Will be deleted after this testing is complete
+    //todo - delete fastlyTestDomainName once the Fastly disaster recovery testing is complete.
+    const fastlyDRTestDomainName = 'cdk-status-resources.guim.co.uk';
 
 		const { loadBalancer } = new GuPlayApp(this, {
 			app: ec2App,
@@ -49,6 +52,16 @@ export class CdkPlayground extends GuStack {
       },
 			imageRecipe: 'developerPlayground-arm64-java11',
 		});
+
+    // This is a temporary domain name for use in some ongoing Fastly Disaster Recovery testing
+    // It will be removed after this testing is complete
+    // todo - remove this Cname after Fastly disaster recovery testing is complete
+    new GuCname(this, 'FastlyDRTestDNS', {
+      app: ec2App,
+      ttl: Duration.hours(1),
+      domainName: fastlyDRTestDomainName,
+      resourceRecord: loadBalancer.loadBalancerDnsName,
+    });
 
 		new GuCname(this, 'EC2AppDNS', {
 			app: ec2App,


### PR DESCRIPTION
## What does this change?
This change adds a domain name to use in a dummy service in Fastly
This is needed to allow us to test Fastlys ability to recover a deleted service.
The domain name in question will be removed once the Fastly disaster recovery testing is complete.

Trello card for reference: https://trello.com/c/cNpLIxz9/2664-rehearse-incident-requiring-fastly-restoration

## How can we measure success?

We are able to set up a Fastly service using the new domain name

## Have we considered potential risks?

Only risk would be if this new domain somehow broke the original, ie if Loadbalancers cannot cope with more than 1 domain being listed against them. If this was the case we would know by attempting to access the service via its existing domain. 

As this is a playground for developers to test on, the impact of this would be negligible.

