### PR TITLE
Remove domain and GuCname used for Fastly DR testing

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -24,7 +24,6 @@ Object {
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuCname",
-      "GuCname",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -270,18 +269,6 @@ Object {
               "DNSName",
             ],
           },
-        ],
-        "Stage": "PROD",
-        "TTL": 3600,
-      },
-      "Type": "Guardian::DNS::RecordSet",
-    },
-    "FastlyDRTestDNS": Object {
-      "Properties": Object {
-        "Name": "cdk-status-resources.guardianapis.com",
-        "RecordType": "CNAME",
-        "ResourceRecords": Array [
-          "dualstack.guardian.map.fastly.net",
         ],
         "Stage": "PROD",
         "TTL": 3600,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -24,9 +24,6 @@ export class CdkPlayground extends GuStack {
 
 		const ec2App = 'cdk-playground';
 		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
-    //New domain added for Fastly disaster recovery testing. Will be deleted after this testing is complete
-    //todo - delete fastlyTestDomainName once the Fastly disaster recovery testing is complete.
-    const fastlyDRTestDomainName = 'cdk-status-resources.guardianapis.com';
 
 		const { loadBalancer } = new GuPlayApp(this, {
 			app: ec2App,
@@ -52,16 +49,6 @@ export class CdkPlayground extends GuStack {
       },
 			imageRecipe: 'developerPlayground-arm64-java11',
 		});
-
-    // This is a temporary domain name for use in some ongoing Fastly Disaster Recovery testing
-    // It will be removed after this testing is complete
-    // todo - remove this Cname after Fastly disaster recovery testing is complete
-    new GuCname(this, 'FastlyDRTestDNS', {
-      app: ec2App,
-      ttl: Duration.hours(1),
-      domainName: fastlyDRTestDomainName,
-      resourceRecord: 'dualstack.guardian.map.fastly.net',
-    });
 
 		new GuCname(this, 'EC2AppDNS', {
 			app: ec2App,


### PR DESCRIPTION
## What does this change?
This is a cleanup PR.

This PR reverses the change made in https://github.com/guardian/cdk-playground/pull/462, removing the domain and GuCname added in that PR for use in a Fastly DR test we were conducting. 

Those additions were simply to provide something to point to from Fastly and made no difference to the real functioning of the cdk-playground.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

No testing needed

## How can we measure success?

It will not be possible to reach cdk-playground.gutools.co.uk by hitting cdk-status-resources.guardianapis.com.

## Have we considered potential risks?

No risks.
