### PR TITLE
wip: Explicitly create log group for lambda

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,3 +52,5 @@ jobs:
               - target/cdk-playground.deb
             cdk-playground-lambda:
               - lambda/cdk-playground-lambda.zip
+            cdk-playground-lambda-test:
+              - lambda/cdk-playground-lambda-test.zip

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -26,6 +26,7 @@ Object {
       "GuCname",
       "GuApiLambda",
       "GuLambdaFunction",
+      "GuLambdaFunction",
       "GuCertificate",
       "GuCname",
     ],
@@ -794,36 +795,6 @@ Object {
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "cdkplaygroundlambdatestloggroupFB2932ED": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "RetentionInDays": 14,
-        "Tags": Array [
-          Object {
-            "Key": "App",
-            "Value": "cdk-playground-lambda-test",
-          },
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "playground",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Delete",
     },
     "lambda8B5974B5": Object {
       "DependsOn": Array [
@@ -1600,6 +1571,206 @@ dpkg -i /cdk-playground/cdk-playground.deb",
       },
       "Type": "AWS::IAM::InstanceProfile",
     },
+    "testlambda27A81A2C6": Object {
+      "DependsOn": Array [
+        "testlambda2ServiceRoleDefaultPolicy5F3C8742",
+        "testlambda2ServiceRoleDCB19148",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "playground/PROD/cdk-playground-lambda-test/cdk-playground-lambda-test.zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "cdk-playground-lambda-test",
+            "STACK": "playground",
+            "STAGE": "PROD",
+          },
+        },
+        "FunctionName": "PROD-playground-cdk-playground-lambda-test",
+        "Handler": "handler.main",
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "testlambda2ServiceRoleDCB19148",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "cdk-playground-lambda-test",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "testlambda2ServiceRoleDCB19148": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "cdk-playground-lambda-test",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testlambda2ServiceRoleDefaultPolicy5F3C8742": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/playground/PROD/cdk-playground-lambda-test/cdk-playground-lambda-test.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:eu-west-1:",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/playground/cdk-playground-lambda-test",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:eu-west-1:",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/playground/cdk-playground-lambda-test/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testlambda2ServiceRoleDefaultPolicy5F3C8742",
+        "Roles": Array [
+          Object {
+            "Ref": "testlambda2ServiceRoleDCB19148",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "testlambdaC73320F8": Object {
       "DependsOn": Array [
         "testlambdaServiceRoleDefaultPolicy2AC3569D",
@@ -1619,12 +1790,8 @@ dpkg -i /cdk-playground/cdk-playground.deb",
             "STAGE": "PROD",
           },
         },
+        "FunctionName": "PROD-playground-cdk-playground-lambda-test",
         "Handler": "handler.main",
-        "LoggingConfig": Object {
-          "LogGroup": Object {
-            "Ref": "cdkplaygroundlambdatestloggroupFB2932ED",
-          },
-        },
         "MemorySize": 512,
         "Role": Object {
           "Fn::GetAtt": Array [
@@ -1673,7 +1840,20 @@ dpkg -i /cdk-playground/cdk-playground.deb",
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": Array [],
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
         "Tags": Array [
           Object {
             "Key": "App",
@@ -1776,19 +1956,6 @@ dpkg -i /cdk-playground/cdk-playground.deb",
                     },
                     ":parameter/PROD/playground/cdk-playground-lambda-test/*",
                   ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "cdkplaygroundlambdatestloggroupFB2932ED",
-                  "Arn",
                 ],
               },
             },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -25,6 +25,7 @@ Object {
       "GuHttpsApplicationListener",
       "GuCname",
       "GuApiLambda",
+      "GuLambdaFunction",
       "GuCertificate",
       "GuCname",
     ],
@@ -793,6 +794,37 @@ Object {
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "cdkplaygroundlambdatestloggroupFB2932ED": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/aws/lambda/PROD/playground/cdk-playground-lambda-test",
+        "RetentionInDays": 14,
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "cdk-playground-lambda-test",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "lambda8B5974B5": Object {
       "DependsOn": Array [
@@ -1568,6 +1600,210 @@ dpkg -i /cdk-playground/cdk-playground.deb",
         ],
       },
       "Type": "AWS::IAM::InstanceProfile",
+    },
+    "testlambdaC73320F8": Object {
+      "DependsOn": Array [
+        "testlambdaServiceRoleDefaultPolicy2AC3569D",
+        "testlambdaServiceRole28D9F97A",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "playground/PROD/cdk-playground-lambda-test/cdk-playground-lambda-test.zip",
+        },
+        "Environment": Object {
+          "Variables": Object {
+            "APP": "cdk-playground-lambda-test",
+            "STACK": "playground",
+            "STAGE": "PROD",
+          },
+        },
+        "Handler": "handler.main",
+        "LoggingConfig": Object {
+          "LogGroup": Object {
+            "Ref": "cdkplaygroundlambdatestloggroupFB2932ED",
+          },
+        },
+        "MemorySize": 512,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "testlambdaServiceRole28D9F97A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "cdk-playground-lambda-test",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "testlambdaServiceRole28D9F97A": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "cdk-playground-lambda-test",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "testlambdaServiceRoleDefaultPolicy2AC3569D": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/playground/PROD/cdk-playground-lambda-test/cdk-playground-lambda-test.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:eu-west-1:",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/playground/cdk-playground-lambda-test",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:eu-west-1:",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/PROD/playground/cdk-playground-lambda-test/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "cdkplaygroundlambdatestloggroupFB2932ED",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "testlambdaServiceRoleDefaultPolicy2AC3569D",
+        "Roles": Array [
+          Object {
+            "Ref": "testlambdaServiceRole28D9F97A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
   },
 }

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -798,7 +798,6 @@ Object {
     "cdkplaygroundlambdatestloggroupFB2932ED": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
-        "LogGroupName": "/aws/lambda/PROD/playground/cdk-playground-lambda-test",
         "RetentionInDays": 14,
         "Tags": Array [
           Object {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -79,30 +79,25 @@ export class CdkPlayground extends GuStack {
 			},
 		});
 
-		// const { stage, stack } = this;
+		const { stack, stage } = this;
+
 		const testLambdaApp = 'cdk-playground-lambda-test';
 
-		const logGroup = new LogGroup(this, `${testLambdaApp}-log-group`, {
-			// logGroupName: `/aws/lambda/${stage}/${stack}/${testLambdaApp}`,
-			retention: 14,
-			removalPolicy: RemovalPolicy.DESTROY,
-		});
-		Tags.of(logGroup).add('App', testLambdaApp);
-
-		const testLambda = new GuLambdaFunction(this, 'test-lambda', {
+		new GuLambdaFunction(this, 'test-lambda', {
 			app: testLambdaApp,
 			fileName: `${testLambdaApp}.zip`,
 			handler: 'handler.main',
 			runtime: Runtime.NODEJS_20_X,
-			logGroup,
+			functionName: [stage, stack, testLambdaApp].join('-'),
 		});
 
-		logGroup.grantWrite(testLambda);
-
-		const { role } = testLambda;
-		if (role) {
-			(role.node.defaultChild as CfnRole).managedPolicyArns = [];
-		}
+		new GuLambdaFunction(this, 'test-lambda-2', {
+			app: testLambdaApp,
+			fileName: `${testLambdaApp}.zip`,
+			handler: 'handler.main',
+			runtime: Runtime.NODEJS_20_X,
+			functionName: [stage, stack, testLambdaApp].join('-'),
+		});
 
 		const domain = lambda.api.addDomainName('domain', {
 			domainName: lambdaDomainName,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -79,11 +79,11 @@ export class CdkPlayground extends GuStack {
 			},
 		});
 
-		const { stage, stack } = this;
+		// const { stage, stack } = this;
 		const testLambdaApp = 'cdk-playground-lambda-test';
 
 		const logGroup = new LogGroup(this, `${testLambdaApp}-log-group`, {
-			logGroupName: `/aws/lambda/${stage}/${stack}/${testLambdaApp}`,
+			// logGroupName: `/aws/lambda/${stage}/${stack}/${testLambdaApp}`,
 			retention: 14,
 			removalPolicy: RemovalPolicy.DESTROY,
 		});

--- a/script/ci
+++ b/script/ci
@@ -13,6 +13,7 @@ set -e
 (
   cd lambda
   zip cdk-playground-lambda.zip handler.js
+  zip cdk-playground-lambda-test.zip handler.js
 )
 
 sbt clean compile test debian:packageBin


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
