### PR TITLE
Configure DNS for test Fastly service

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -24,6 +24,7 @@ Object {
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuCname",
+      "GuCname",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -269,6 +270,18 @@ Object {
               "DNSName",
             ],
           },
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "FastlyDNS": Object {
+      "Properties": Object {
+        "Name": "cdn-playground.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": Array [
+          "dualstack.guardian.map.fastly.net",
         ],
         "Stage": "PROD",
         "TTL": 3600,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -57,6 +57,15 @@ export class CdkPlayground extends GuStack {
 			resourceRecord: loadBalancer.loadBalancerDnsName,
 		});
 
+    // This is a temporary domain name to support testing with a Fastly service.
+    // It will be removed when testing is complete.
+    new GuCname(this, 'FastlyDNS', {
+      app: ec2App,
+      ttl: Duration.hours(1),
+      domainName: 'cdn-playground.gutools.co.uk',
+      resourceRecord: 'dualstack.guardian.map.fastly.net',
+    });
+
 		const lambdaApp = 'cdk-playground-lambda';
 		const lambdaDomainName = 'cdk-playground-lambda.gutools.co.uk';
 


### PR DESCRIPTION
Similar to https://github.com/guardian/cdk-playground/pull/462.

I want to put a Fastly service in front of this app to simplify/de-risk the testing for [this card](https://trello.com/c/JKlLGC8b/2744-spike-determine-how-to-get-fastly-metrics-into-cloudwatch).

I will revert this PR when the testing is complete.
