### PR TITLE
Modify Fastly DNS name to resolve certificate problem

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -278,7 +278,7 @@ Object {
     },
     "FastlyDNS": Object {
       "Properties": Object {
-        "Name": "cdn-playground.gutools.co.uk",
+        "Name": "cdn-playground.code.dev-guardianapis.com",
         "RecordType": "CNAME",
         "ResourceRecords": Array [
           "dualstack.guardian.map.fastly.net",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -62,7 +62,7 @@ export class CdkPlayground extends GuStack {
     new GuCname(this, 'FastlyDNS', {
       app: ec2App,
       ttl: Duration.hours(1),
-      domainName: 'cdn-playground.gutools.co.uk',
+      domainName: 'cdn-playground.code.dev-guardianapis.com',
       resourceRecord: 'dualstack.guardian.map.fastly.net',
     });
 


### PR DESCRIPTION
Follow up to https://github.com/guardian/cdk-playground/pull/479. 

`gutools.co.uk` was a bad choice of domain name because our Fastly certificate does not include `*gutools.co.uk` as a subject alt name. `*.code.dev-guardianapis.com` is listed as a subject alt name, so let's use that domain instead[^1].

[^1]: We're just using this for testing, so the domain name doesn't really matter.