### PR TITLE
Provision a role for Fastly log shipping

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -25,6 +25,10 @@ Object {
       "GuHttpsApplicationListener",
       "GuCname",
       "GuCname",
+      "GuStringParameter",
+      "GuFastlyCustomerIdParameter",
+      "GuFastlyLogsIamRole",
+      "GuPutS3ObjectsPolicy",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -72,6 +76,18 @@ Object {
     "DistributionBucketName": Object {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "FastlyBucket": Object {
+      "AllowedValues": Array [
+        "/PROD/playground/cdk-playground/fastly-logs-bucket",
+      ],
+      "Default": "/PROD/playground/cdk-playground/fastly-logs-bucket",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "FastlyCustomerId": Object {
+      "Default": "/account/external/fastly/customer.id",
+      "Description": "SSM parameter containing the Fastly Customer ID. Can be obtained from https://manage.fastly.com/account/company by an admin",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "LoggingStreamName": Object {
@@ -315,6 +331,91 @@ Object {
         "Roles": Array [
           Object {
             "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuFastlyLogsIamRoleE2DAFAB3": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:ExternalId": Object {
+                    "Ref": "FastlyCustomerId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::717331877981:root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "GuFastlyLogsIamRolePolicy5BF3CDCA": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "FastlyBucket",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuFastlyLogsIamRolePolicy5BF3CDCA",
+        "Roles": Array [
+          Object {
+            "Ref": "GuFastlyLogsIamRoleE2DAFAB3",
           },
         ],
       },


### PR DESCRIPTION
This PR builds upon https://github.com/guardian/cdk-playground/pull/479 and https://github.com/guardian/cdk-playground/pull/480.

Now that we are using Fastly to route requests to this application, we can enable [log streaming](https://docs.fastly.com/en/guides/about-fastlys-realtime-log-streaming-features) via the Fastly service. In order to do this, [we need to give Fastly permissions to push log files into our S3 bucket](https://docs.fastly.com/en/guides/log-streaming-amazon-s3#adding-amazon-s3-as-a-logging-endpoint), so this PR uses GuCDK constructs to create an appropriate IAM role.

The ARN of the IAM role that we create here (and the name of the bucket, which is created by https://github.com/guardian/fastly-logs-to-metrics) has already been wired up to the service's logging configuration (via the Fastly UI). 

I have deployed this branch and I can see logs appearing in S3:

![image](https://github.com/guardian/cdk-playground/assets/19384074/ac7b6712-a6c5-4a1f-8be8-fd1348a1c22c)