### PR TITLE
Add some new routes for response code testing

### DIFF
--- a/app/controllers/ManagementController.scala
+++ b/app/controllers/ManagementController.scala
@@ -18,4 +18,17 @@ class ManagementController (override val controllerComponents: ControllerCompone
     logger.info("hello from the health check")
     Ok("OK")
   }
+
+  def movedPermanently: Action[AnyContent] = Action {
+    MovedPermanently("https://www.theguardian.com/uk")
+  }
+
+  def badRequest: Action[AnyContent] = Action {
+    BadRequest
+  }
+
+  def error: Action[AnyContent] = Action {
+    InternalServerError
+  }
+
 }

--- a/conf/routes
+++ b/conf/routes
@@ -1,5 +1,8 @@
 GET     /                           controllers.ManagementController.manifest
 GET     /healthcheck                controllers.ManagementController.healthCheck
+GET     /moved-permanently          controllers.ManagementController.movedPermanently
+GET     /bad-request                controllers.ManagementController.badRequest
+GET     /error                      controllers.ManagementController.error
 GET     /robots.txt                 controllers.ManagementController.disallowRobots
 
 # Map static resources from the /public folder to the /assets URL path


### PR DESCRIPTION
This allows us to more easily test functionality that depends on specific status codes being served (e.g. alarms, metric collection and dashboards).