### PR TITLE
Fix `npm run diff` script

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -3,4 +3,6 @@ import { GuRoot } from '@guardian/cdk/lib/constructs/root';
 import { CdkPlayground } from '../lib/cdk-playground';
 
 const app = new GuRoot();
-new CdkPlayground(app, 'CdkPlayground');
+new CdkPlayground(app, 'CdkPlayground', {
+	cloudFormationStackName: 'playground-PROD-cdk-playground',
+});

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node bin/cdk.ts",
+  "profile": "developerPlayground",
   "context": {
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true"


### PR DESCRIPTION
## What does this change?
Set the CloudFormation stack name, and AWS profile to enable `npm run diff` to work.

