### PR TITLE
chore(deps): Update GuCDK from 59.2.3 to 59.2.4

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,13 +8,13 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "59.2.3",
+        "@guardian/cdk": "59.2.4",
         "@guardian/eslint-config-typescript": "5.0.0",
         "@guardian/prettier": "8.0.1",
         "@types/jest": "^28.1.6",
         "@types/node": "22.4.1",
-        "aws-cdk": "2.148.0",
-        "aws-cdk-lib": "2.148.0",
+        "aws-cdk": "2.153.0",
+        "aws-cdk-lib": "2.153.0",
         "constructs": "10.3.0",
         "jest": "^28.1.3",
         "source-map-support": "^0.5.20",
@@ -787,13 +787,13 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "59.2.3",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.2.3.tgz",
-      "integrity": "sha512-kOjtMKx6TFgxVOgpZ7KEGC1G/iGSKbiYlqq/1W93qIelu+s5eug/c5Nc5GQjc8ABS4uz8uJp34fdUNb19LkqRw==",
+      "version": "59.2.4",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.2.4.tgz",
+      "integrity": "sha512-EAkPhr2t3Jp4BKUt0h+taOFMKyW290eskPXhqsVJEn/rnjR1Nm8AoHTCSZfv1YQeweSrLGl+GumbhkTclLaDOw==",
       "dev": true,
       "dependencies": {
         "@oclif/core": "3.26.6",
-        "aws-sdk": "^2.1670.0",
+        "aws-sdk": "^2.1674.0",
         "chalk": "^4.1.2",
         "codemaker": "^1.102.0",
         "git-url-parse": "^14.1.0",
@@ -808,8 +808,8 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.148.0",
-        "aws-cdk-lib": "2.148.0",
+        "aws-cdk": "2.153.0",
+        "aws-cdk-lib": "2.153.0",
         "constructs": "10.3.0"
       }
     },
@@ -2089,9 +2089,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.148.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.148.0.tgz",
-      "integrity": "sha512-nuCWY8I0xkIz7B2LjIL4h/xLHWTFhINL8i2fdA0BPq8t0byhLaNw5wggvztDjWH5xq5I1DM3laiv4/q5S21Xrg==",
+      "version": "2.153.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.153.0.tgz",
+      "integrity": "sha512-cBP+K9/BH0VpkNkm61c/1UCdY7MCUXxRTEUYT1TNDSR9rJQPseaeKWNwtt31KxvT6xbgoskh0NTOpy7t+bqWUw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2104,9 +2104,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.148.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.148.0.tgz",
-      "integrity": "sha512-Pa0pyIHlhnsqtMkPJS3tnptYhoOSNDOgoFurNB4Qfa0vnAkjYQ+JKQkR1tNNr8+UtO9jUfXRklQgjEqlFlrgBA==",
+      "version": "2.153.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.153.0.tgz",
+      "integrity": "sha512-wj8NnZb/F/SZGz7SqMgXL5eAu4CkJdjUIzDDXh16Fdo7vE8o59qFGZz8m0vA4aTXG10jtWxnJwAfoQPgzXqFCw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2481,9 +2481,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1672.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1672.0.tgz",
-      "integrity": "sha512-en4uaVWE/wPa9YsF2XAYtKP0hLQ10s93/nWe+SQ8Yox1xrDn1Tr32MMOtSLRXLxPRKcvmI7Yzw7jiQMgs1jqBQ==",
+      "version": "2.1678.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1678.0.tgz",
+      "integrity": "sha512-7+MNi7hholVrQYBu8bVbfzOBHxKlC63BfuxUwwMaUrFN1hok4pdB0QsEvL6YHwZtF+3Bq5zhONImnT2Q7W15yg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -6228,7 +6228,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,13 +11,13 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "59.2.3",
+    "@guardian/cdk": "59.2.4",
     "@guardian/eslint-config-typescript": "5.0.0",
     "@guardian/prettier": "8.0.1",
     "@types/jest": "^28.1.6",
     "@types/node": "22.4.1",
-    "aws-cdk": "2.148.0",
-    "aws-cdk-lib": "2.148.0",
+    "aws-cdk": "2.153.0",
+    "aws-cdk-lib": "2.153.0",
     "constructs": "10.3.0",
     "jest": "^28.1.3",
     "source-map-support": "^0.5.20",


### PR DESCRIPTION
Update GuCDK version. Release notes here - https://github.com/guardian/cdk/releases/tag/v59.2.4.