### PR TITLE
feat: Add build info as stack metadata and ASG tags

### DIFF
--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,1 +1,4 @@
-jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+jest.mock('@guardian/cdk/lib/constants/tracking-tag');
+
+process.env.GITHUB_RUN_NUMBER = 'TEST';
+process.env.GITHUB_SHA = 'TEST';

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -3,6 +3,8 @@
 exports[`The Deploy stack matches the snapshot 1`] = `
 Object {
   "Metadata": Object {
+    "gu:build:number": "TEST",
+    "gu:build:sha": "TEST",
     "gu:cdk:constructs": Array [
       "GuVpcParameter",
       "GuSubnetListParameter",
@@ -144,6 +146,16 @@ Object {
             "Key": "App",
             "PropagateAtLaunch": true,
             "Value": "cdk-playground",
+          },
+          Object {
+            "Key": "gu:build:number",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:build:sha",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -6,7 +6,7 @@ import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuFastlyLogsIamRole } from '@guardian/cdk/lib/constructs/iam';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Tags } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
@@ -26,7 +26,7 @@ export class CdkPlayground extends GuStack {
 		const ec2App = 'cdk-playground';
 		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
 
-		const { loadBalancer } = new GuPlayApp(this, {
+		const { loadBalancer, autoScalingGroup } = new GuPlayApp(this, {
 			app: ec2App,
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 			access: { scope: AccessScope.PUBLIC },
@@ -109,5 +109,14 @@ export class CdkPlayground extends GuStack {
 			domainName: lambdaDomainName,
 			resourceRecord: domain.domainNameAliasDomainName,
 		});
+
+		const { GITHUB_RUN_NUMBER = 'unknown', GITHUB_SHA = 'unknown' } =
+			process.env;
+
+		this.addMetadata('gu:build:number', GITHUB_RUN_NUMBER);
+		this.addMetadata('gu:build:sha', GITHUB_SHA);
+
+		Tags.of(autoScalingGroup).add('gu:build:number', GITHUB_RUN_NUMBER);
+		Tags.of(autoScalingGroup).add('gu:build:sha', GITHUB_SHA);
 	}
 }


### PR DESCRIPTION
Adds two new tags to the ASG:
- `gu:build:number`
- `gu:build:sha`

These values are also added as stack metadata. The tags are not added to all resources to reduce noise in the CloudFormation logs.

This makes the changes in #512 more useful, and potentially paves the way to remove the [`sbt-buildinfo` plugin](https://github.com/guardian/cdk-playground/blob/264e42d6540d11cf34d6d0c6a67e3a56565f6c5e/build.sbt#L44-L60).