### PR TITLE
feat: Use `GuEc2AppExperimental` to perform EC2 deployments via CloudFormation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,6 @@ jobs:
             cdk.out:
               - cdk/cdk.out
             cdk-playground:
-              - target/cdk-playground.deb
+              - dist/cdk-playground
             cdk-playground-lambda:
               - lambda/cdk-playground-lambda.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 logs
 lambda/cdk-playground-lambda.zip
+dist/

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -1639,13 +1639,13 @@ exitCode=$?
         
 }
 trap exitTrap EXIT
-mkdir -p $(dirname '/cdk-playground/cdk-playground.deb')
+mkdir -p $(dirname '/cdk-playground/cdk-playground-TEST.deb')
 aws s3 cp 's3://",
                   Object {
                     "Ref": "DistributionBucketName",
                   },
-                  "/playground/PROD/cdk-playground/cdk-playground.deb' '/cdk-playground/cdk-playground.deb'
-dpkg -i /cdk-playground/cdk-playground.deb
+                  "/playground/PROD/cdk-playground/cdk-playground-TEST.deb' '/cdk-playground/cdk-playground-TEST.deb'
+dpkg -i /cdk-playground/cdk-playground-TEST.deb
 # GuEc2AppExperimental UserData Start
 
       TOKEN=$(curl -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 21600\\")

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
-      "GuPlayApp",
+      "GuEc2AppExperimental",
       "GuDistributionBucketParameter",
       "GuCertificate",
       "GuInstanceRole",
@@ -98,8 +98,46 @@ Object {
     },
   },
   "Resources": Object {
-    "AutoScalingGroupCdkplaygroundASGD6E49F0F": Object {
+    "AsgRollingUpdatePolicy2A1DDC6F": Object {
       "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudformation:SignalResource",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "AWS::StackId",
+              },
+            },
+            Object {
+              "Action": "elasticloadbalancing:DescribeTargetHealth",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupCdkplaygroundASGD6E49F0F": Object {
+      "CreationPolicy": Object {
+        "AutoScalingCreationPolicy": Object {
+          "MinSuccessfulInstancesPercent": 100,
+        },
+        "ResourceSignal": Object {
+          "Count": 1,
+          "Timeout": "PT2M",
+        },
+      },
+      "Properties": Object {
+        "DesiredCapacity": "1",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": Object {
@@ -179,6 +217,18 @@ Object {
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": Object {
+        "AutoScalingRollingUpdate": Object {
+          "MaxBatchSize": 2,
+          "MinInstancesInService": 1,
+          "MinSuccessfulInstancesPercent": 100,
+          "PauseTime": "PT2M",
+          "SuspendProcesses": Array [
+            "AlarmNotification",
+          ],
+          "WaitOnResourceSignals": true,
+        },
+      },
     },
     "CertificateCdkplayground47FCF7D9": Object {
       "DeletionPolicy": "Retain",
@@ -1578,13 +1628,48 @@ Object {
                 "",
                 Array [
                   "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  Object {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupCdkplaygroundASGD6E49F0F           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
 mkdir -p $(dirname '/cdk-playground/cdk-playground.deb')
 aws s3 cp 's3://",
                   Object {
                     "Ref": "DistributionBucketName",
                   },
                   "/playground/PROD/cdk-playground/cdk-playground.deb' '/cdk-playground/cdk-playground.deb'
-dpkg -i /cdk-playground/cdk-playground.deb",
+dpkg -i /cdk-playground/cdk-playground.deb
+# GuEc2AppExperimental UserData Start
+
+      TOKEN=$(curl -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 21600\\")
+      INSTANCE_ID=$(curl -H \\"X-aws-ec2-metadata-token: $TOKEN\\" \\"http://169.254.169.254/latest/meta-data/instance-id\\")
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  Object {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=9000         --query \\"TargetHealthDescriptions[0].TargetHealth.State\\")
+
+      until [ \\"$STATE\\" == \\"\\\\\\"healthy\\\\\\"\\" ]; do
+        echo \\"Instance not yet healthy within target group. Current state $STATE. Sleeping...\\"
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  Object {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=9000           --query \\"TargetHealthDescriptions[0].TargetHealth.State\\")
+      done
+
+      echo \\"Instance is healthy in target group.\\"
+      
+# GuEc2AppExperimental UserData End",
                 ],
               ],
             },

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -26,6 +26,8 @@ export class CdkPlayground extends GuStack {
 		const ec2App = 'cdk-playground';
 		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
 
+    const buildNumber = process.env.GITHUB_RUN_NUMBER ?? 'DEV';
+
 		const { loadBalancer, autoScalingGroup } = new GuEc2AppExperimental(this, {
 			applicationPort: 9000,
 			app: ec2App,
@@ -33,8 +35,8 @@ export class CdkPlayground extends GuStack {
 			access: { scope: AccessScope.PUBLIC },
 			userData: {
 				distributable: {
-					fileName: `${ec2App}.deb`,
-					executionStatement: `dpkg -i /${ec2App}/${ec2App}.deb`,
+					fileName: `${ec2App}-${buildNumber}.deb`,
+					executionStatement: `dpkg -i /${ec2App}/${ec2App}-${buildNumber}.deb`,
 				},
 			},
 			certificateProps: {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -1,9 +1,10 @@
-import { GuApiLambda, GuPlayApp } from '@guardian/cdk';
+import { GuApiLambda } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { Duration, Tags } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
@@ -25,7 +26,8 @@ export class CdkPlayground extends GuStack {
 		const ec2App = 'cdk-playground';
 		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
 
-		const { loadBalancer, autoScalingGroup } = new GuPlayApp(this, {
+		const { loadBalancer, autoScalingGroup } = new GuEc2AppExperimental(this, {
+			applicationPort: 9000,
 			app: ec2App,
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 			access: { scope: AccessScope.PUBLIC },

--- a/script/ci
+++ b/script/ci
@@ -17,5 +17,5 @@ set -e
 
 sbt clean compile test debian:packageBin
 
-# `sbt debian:packageBin` produces `target/cdk-playground_1.0-SNAPSHOT_all.deb`. Rename it to something easier.
-mv target/cdk-playground_1.0-SNAPSHOT_all.deb target/cdk-playground.deb
+mkdir -p dist/cdk-playground
+mv target/cdk-playground_1.0-SNAPSHOT_all.deb "dist/cdk-playground/cdk-playground-$GITHUB_RUN_NUMBER.deb"


### PR DESCRIPTION
## What does this change?
Uses the new `GuEc2AppExperimental` available in [GuCDK v59.5.0](https://github.com/guardian/cdk/releases/tag/v59.5.0).

This formalises the changes of https://github.com/guardian/cdk-playground/pull/522, installing the experimental pattern from an NPM release.

## How to test
N/A as testing has been performed in https://github.com/guardian/cdk-playground/pull/522.