### PR TITLE
chore(deps-dev): Update GuCDK from 59.5.0 to 59.5.1

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -133,7 +133,7 @@ Object {
         },
         "ResourceSignal": Object {
           "Count": 1,
-          "Timeout": "PT2M",
+          "Timeout": "PT3M",
         },
       },
       "Properties": Object {
@@ -222,7 +222,7 @@ Object {
           "MaxBatchSize": 2,
           "MinInstancesInService": 1,
           "MinSuccessfulInstancesPercent": 100,
-          "PauseTime": "PT2M",
+          "PauseTime": "PT3M",
           "SuspendProcesses": Array [
             "AlarmNotification",
           ],

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "59.5.0",
+        "@guardian/cdk": "59.5.1",
         "@guardian/eslint-config-typescript": "5.0.0",
         "@guardian/prettier": "8.0.1",
         "@types/jest": "^28.1.6",
@@ -825,9 +825,9 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "59.5.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.5.0.tgz",
-      "integrity": "sha512-cmdh/V0+SxhPC4qsqIiQ1Axdh+133s7oJv63SxCu/OGAp49XclLVOL2TA00bsVJC0ozI8pUMU1h+di0yTaDgyA==",
+      "version": "59.5.1",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.5.1.tgz",
+      "integrity": "sha512-BqLRnRGICL4O2NPUTT7yvReDIMNC4rGBxAwImSE5j6eu9OkwbpqzdrrvdB7USATyhq5VDc4sEO3QqpGcnRprUw==",
       "dev": true,
       "dependencies": {
         "@oclif/core": "3.26.6",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,7 +11,7 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "59.5.0",
+    "@guardian/cdk": "59.5.1",
     "@guardian/eslint-config-typescript": "5.0.0",
     "@guardian/prettier": "8.0.1",
     "@types/jest": "^28.1.6",


### PR DESCRIPTION
## What does this change?
Update the version of GuCDK. This should improve the stability of deployments. See https://github.com/guardian/cdk/pull/2462.
