### PR TITLE
Pass build identifier as prop

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -5,4 +5,5 @@ import { CdkPlayground } from '../lib/cdk-playground';
 const app = new GuRoot();
 new CdkPlayground(app, 'CdkPlayground', {
 	cloudFormationStackName: 'playground-PROD-cdk-playground',
+	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 });

--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,4 +1,1 @@
 jest.mock('@guardian/cdk/lib/constants/tracking-tag');
-
-process.env.GITHUB_RUN_NUMBER = 'TEST';
-process.env.GITHUB_SHA = 'TEST';

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -3,8 +3,6 @@
 exports[`The Deploy stack matches the snapshot 1`] = `
 Object {
   "Metadata": Object {
-    "gu:build:number": "TEST",
-    "gu:build:sha": "TEST",
     "gu:cdk:constructs": Array [
       "GuVpcParameter",
       "GuSubnetListParameter",
@@ -163,16 +161,6 @@ Object {
             "Key": "App",
             "PropagateAtLaunch": true,
             "Value": "cdk-playground",
-          },
-          Object {
-            "Key": "gu:build:number",
-            "PropagateAtLaunch": true,
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:build:sha",
-            "PropagateAtLaunch": true,
-            "Value": "TEST",
           },
           Object {
             "Key": "gu:cdk:version",

--- a/cdk/lib/cdk-playground.test.ts
+++ b/cdk/lib/cdk-playground.test.ts
@@ -5,7 +5,9 @@ import { CdkPlayground } from './cdk-playground';
 describe('The Deploy stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
-		const stack = new CdkPlayground(app, 'CdkPlayground');
+		const stack = new CdkPlayground(app, 'CdkPlayground', {
+			buildIdentifier: 'TEST',
+		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
Reverts #513 and removes the need to use a Jest mock.