### PR TITLE
Intentionally fail the health check

### DIFF
--- a/app/controllers/ManagementController.scala
+++ b/app/controllers/ManagementController.scala
@@ -33,7 +33,7 @@ class ManagementController (override val controllerComponents: ControllerCompone
 
   def healthCheck: Action[AnyContent] = Action {
     logger.info("hello from the health check")
-    Ok("OK")
+    InternalServerError
   }
 
   def movedPermanently: Action[AnyContent] = Action {


### PR DESCRIPTION
This change intentionally breaks the health check for the purposes of demonstrating the behaviour of the [`GuEc2AppExperimental` pattern from GuCDK](https://github.com/guardian/cdk/blob/main/src/experimental/patterns/ec2-app.ts) that uses [AutoScalingRollingUpdate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-rollingupdate).

This demo is for Engineering All Hands at 10AM Tuesday 24 September 2024.
- 📝  [Slides can be found here (internal only)](https://docs.google.com/presentation/d/1a2Imu-ZRg3KdQt67bLp188dyCMEaXRzSzMc-4RvvIuM/edit#slide=id.p)
- 📹 [A recording can be found here (internal only)](https://drive.google.com/file/d/1JMppUIilp6M0b08cBnAd18-rGDYpAWrD/view)