### PR TITLE
feat: Add scripts to trigger ASG scale in/out events

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ That is, CDK Playground offers a low risk environment to experiment with.
 The CDK stack is defined in the [cdk](./cdk) directory.
 
 There are a couple of helpful scripts in the [script](./script) directory:
-  1. `./script/start-play` to run the Play app
-  1. `./script/start-cdk` to start Jest in watch mode, to test the CDK stack
-  1. `./script/build-cdk` to synthesise the CDK stack into a template
-  1. `./script/switch-cdk` to install GuCDK from a GitHub branch. This is useful to test changes _without_ publishing to NPM first.
+1. `./script/start-play` to run the Play app
+2. `./script/start-cdk` to start Jest in watch mode, to test the CDK stack
+3. `./script/build-cdk` to synthesise the CDK stack into a template
+4. `./script/switch-cdk` to install GuCDK from a GitHub branch. This is useful to test changes _without_ publishing to NPM first.
+5. `./script/scale-out` to simulate a scale out event, increasing the capacity of the autoscaling group
+6. `./script/scale-in` to simulate a scale in event, decreasing the capacity of the autoscaling group
 
 ## Deploying
 The app is set up in the usual way, with CI on each branch (via GitHub Actions) and [CD](https://riffraff.gutools.co.uk/deployment/history?projectName=devx%3A%3Acdk-playground&stage=PROD&pageSize=20&page=1) on `main`.

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -102,7 +102,7 @@ Object {
     },
     "MinInstancesInServiceForcdkplayground": Object {
       "Default": 1,
-      "MaxValue": 1,
+      "MaxValue": 9,
       "Type": "Number",
     },
     "VpcId": Object {
@@ -177,7 +177,7 @@ Object {
             ],
           },
         },
-        "MaxSize": "2",
+        "MaxSize": "10",
         "MetricsCollection": Array [
           Object {
             "Granularity": "1Minute",
@@ -235,7 +235,7 @@ Object {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy": Object {
         "AutoScalingRollingUpdate": Object {
-          "MaxBatchSize": 2,
+          "MaxBatchSize": 10,
           "MinInstancesInService": Object {
             "Ref": "MinInstancesInServiceForcdkplayground",
           },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -32,12 +32,33 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Outputs": Object {
+    "AutoscalingGroupName": Object {
+      "Value": Object {
+        "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
+      },
+    },
     "LoadBalancerCdkplaygroundDnsName": Object {
       "Description": "DNS entry for LoadBalancerCdkplayground",
       "Value": Object {
         "Fn::GetAtt": Array [
           "LoadBalancerCdkplayground7C6B4D97",
           "DNSName",
+        ],
+      },
+    },
+    "ScaleInArn": Object {
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "AutoScalingGroupCdkplaygroundScaleIn24F0C6B8",
+          "Arn",
+        ],
+      },
+    },
+    "ScaleOutArn": Object {
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "AutoScalingGroupCdkplaygroundScaleOutA06BF2EE",
+          "Arn",
         ],
       },
     },
@@ -78,6 +99,11 @@ Object {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "MinInstancesInServiceForcdkplayground": Object {
+      "Default": 1,
+      "MaxValue": 1,
+      "Type": "Number",
     },
     "VpcId": Object {
       "Default": "/account/vpc/primary/id",
@@ -138,7 +164,6 @@ Object {
         "AsgRollingUpdatePolicy2A1DDC6F",
       ],
       "Properties": Object {
-        "DesiredCapacity": "1",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": Object {
@@ -211,7 +236,9 @@ Object {
       "UpdatePolicy": Object {
         "AutoScalingRollingUpdate": Object {
           "MaxBatchSize": 2,
-          "MinInstancesInService": 1,
+          "MinInstancesInService": Object {
+            "Ref": "MinInstancesInServiceForcdkplayground",
+          },
           "MinSuccessfulInstancesPercent": 100,
           "PauseTime": "PT3M",
           "SuspendProcesses": Array [
@@ -220,6 +247,28 @@ Object {
           "WaitOnResourceSignals": true,
         },
       },
+    },
+    "AutoScalingGroupCdkplaygroundScaleIn24F0C6B8": Object {
+      "Properties": Object {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": Object {
+          "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": -1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "AutoScalingGroupCdkplaygroundScaleOutA06BF2EE": Object {
+      "Properties": Object {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": Object {
+          "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": 1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
     },
     "CertificateCdkplayground47FCF7D9": Object {
       "DeletionPolicy": "Retain",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -54,7 +54,7 @@ export class CdkPlayground extends GuStack {
 			monitoringConfiguration: { noMonitoring: true },
 			scaling: {
 				minimumInstances: 1,
-				maximumInstances: 2,
+				maximumInstances: 10,
 			},
 			applicationLogging: {
 				enabled: true,

--- a/script/scale-in
+++ b/script/scale-in
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+CLOUDFORMATION_STACK_NAME=playground-PROD-cdk-playground
+
+POLICY_ARN=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleInArn") ] | any) | .OutputValue'
+)
+
+ASG_NAME=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
+)
+
+CURRENT_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+aws autoscaling execute-policy \
+  --policy-name "$POLICY_ARN" \
+  --profile developerPlayground \
+  --region eu-west-1
+
+NEW_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+echo "Desired capacity has been updated from $CURRENT_DESIRED_CAPACITY to $NEW_DESIRED_CAPACITY"

--- a/script/scale-out
+++ b/script/scale-out
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+CLOUDFORMATION_STACK_NAME=playground-CODE-scaling-asg-rolling-update
+
+POLICY_ARN=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleOutArn") ] | any) | .OutputValue'
+)
+
+ASG_NAME=$(
+  aws cloudformation describe-stacks \
+      --stack-name "$CLOUDFORMATION_STACK_NAME" \
+      --profile developerPlayground \
+      --region eu-west-1 \
+      --no-cli-pager | \
+      jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
+)
+
+CURRENT_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+aws autoscaling execute-policy \
+  --policy-name "$POLICY_ARN" \
+  --profile developerPlayground \
+  --region eu-west-1
+
+NEW_DESIRED_CAPACITY=$(
+  aws autoscaling describe-auto-scaling-groups \
+    --auto-scaling-group-names "$ASG_NAME" \
+    --profile developerPlayground \
+    --region eu-west-1 | \
+    jq -r '.AutoScalingGroups[].DesiredCapacity'
+)
+
+echo "Desired capacity has been updated from $CURRENT_DESIRED_CAPACITY to $NEW_DESIRED_CAPACITY"


### PR DESCRIPTION
## What does this change?
Add some simple scaling policies to the autoscaling group. This allows us to use the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/execute-policy.html) to programatically trigger a scale in/out event.

Using simple scaling, over target tracking scaling, makes it easier to test certain deployment situations,
as scaling events become somewhat deterministic.

## Example usage

```console
❯ ./script/scale-out
Desired capacity has been updated from 1 to 2

❯ ./script/scale-in 
Desired capacity has been updated from 2 to 1
```