### PR TITLE
Switch to manual `riff-raff.yaml` file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           commentingStage: 'PROD'
-          configPath: cdk/cdk.out/riff-raff.yaml
+          configPath: riff-raff.yaml
           contentDirectories: |
             cdk.out:
               - cdk/cdk.out

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,39 @@
+allowedStages:
+  - PROD
+deployments:
+  # This deployment uploads the application artifact (.deb file) to S3.
+  asg-upload-eu-west-1-playground-cdk-playground:
+    type: autoscaling
+    actions:
+      - uploadArtifacts
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    parameters:
+      bucketSsmLookup: true
+      prefixApp: true
+    contentDirectory: cdk-playground
+
+  # This deployment updates the CloudFormation stack.
+  # It will start once the above deployment has completed.
+  cfn-eu-west-1-playground-cdk-playground:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        PROD: CdkPlayground.template.json
+      amiParametersToTags:
+        AMICdkplayground:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: developerPlayground-arm64-java11
+          Encrypted: 'true'
+    dependencies:
+      - asg-upload-eu-west-1-playground-cdk-playground


### PR DESCRIPTION
## What does this change?
This is to allow testing of https://github.com/guardian/riff-raff/pull/1383 whilst the `riff-raff.yaml` generator from GuCDK hasn't been updated.

This `riff-raff.yaml` is a stripped down version of the generated one, only uploading the application artifact to S3, and deploying the application CloudFormation stack.

## How to test?
With https://github.com/guardian/riff-raff/pull/1383 on Riff-Raff CODE, and starting with [`main` being deployed](https://riffraff.code.dev-gutools.co.uk/deployment/view/6ba6246e-790c-415d-9421-e2b5502a4d40), this branch should [deploy successfully](https://riffraff.code.dev-gutools.co.uk/deployment/view/cb8577e0-7717-4f34-a126-454f32de5e52), as normal.

This service uses the `GuEc2AppExperimental` pattern from GuCDK (#526). A "normal" deployment means CFN doubles the capacity of the ASG, waits for new instances to send a `SUCCESS` signal, then terminates old instances by halving ASG capacity. Indeed, this is [what was observed](https://metrics.gutools.co.uk/d/adyqx5hf3w1s0e/cdk-playground?orgId=1&from=1728653082346&to=1728653334575).