### PR TITLE
Set the `minInstancesInServiceParameters` property

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           commentingStage: 'PROD'
-          configPath: cdk/cdk.out/riff-raff.yaml
+          configPath: riff-raff.yaml
           contentDirectories: |
             cdk.out:
               - cdk/cdk.out

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -35,5 +35,8 @@ deployments:
           AmigoStage: PROD
           Recipe: developerPlayground-arm64-java11
           Encrypted: 'true'
+      minInstancesInServiceParameters:
+        MinInstancesInServiceForcdkplayground:
+          App: cdk-playground
     dependencies:
       - asg-upload-eu-west-1-playground-cdk-playground

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,39 @@
+allowedStages:
+  - PROD
+deployments:
+  # This deployment uploads the application artifact (.deb file) to S3.
+  asg-upload-eu-west-1-playground-cdk-playground:
+    type: autoscaling
+    actions:
+      - uploadArtifacts
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    parameters:
+      bucketSsmLookup: true
+      prefixApp: true
+    contentDirectory: cdk-playground
+
+  # This deployment updates the CloudFormation stack.
+  # It will start once the above deployment has completed.
+  cfn-eu-west-1-playground-cdk-playground:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        PROD: CdkPlayground.template.json
+      amiParametersToTags:
+        AMICdkplayground:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: developerPlayground-arm64-java11
+          Encrypted: 'true'
+    dependencies:
+      - asg-upload-eu-west-1-playground-cdk-playground


### PR DESCRIPTION
## What does this change?
This is to allow testing of https://github.com/guardian/riff-raff/pull/1383 whilst the `riff-raff.yaml` generator from GuCDK hasn't been updated.

This `riff-raff.yaml` is a stripped down version of the generated one, only uploading the application artifact to S3, and deploying the application CloudFormation stack.

## How to test?
This branch can test multiple scenarios.

> [!NOTE]
> All scenarios match [previously observed behaviour](https://github.com/guardian/testing-asg-rolling-update/tree/main/observations) regarding number of in service instances.

### "Normal" capacity (i.e. `desired = min`)
With the ASG operating at normal capacity, the [deployment](https://riffraff.code.dev-gutools.co.uk/deployment/view/698cb729-b5b1-4475-af01-0c76cbdc91c2) was also [normal](https://metrics.gutools.co.uk/d/adyqx5hf3w1s0e/cdk-playground?orgId=1&from=1728655030000&to=1728655200000).

The deployment log also shows the value of the `MinInstancesInServiceForcdkplayground` CFN parameter was, expectedly, set to match the desired capacity (1).

![image](https://github.com/user-attachments/assets/cf52c8a0-0c4c-4db9-8cfe-e21e58055976)

### Partially scaled (i.e. `min < desired < max`)
Before a deployment was started, the [`scale-out` script](https://github.com/guardian/cdk-playground/blob/main/script/scale-out) was executed a few times, causing the ASG to have `min=1`, `desired=5`, `max=10`.

The [deployment](https://riffraff.code.dev-gutools.co.uk/deployment/view/c6bfd8b8-1dbe-45ba-b109-9056ed54958a) was normal and the deployment log shows the value of the `MinInstancesInServiceForcdkplayground` CFN parameter was, expectedly, set to match the current desired capacity (5):

![image](https://github.com/user-attachments/assets/bcfc8208-0b88-4cf9-baa1-d2234c455f08)

The [metrics](https://metrics.gutools.co.uk/d/adyqx5hf3w1s0e/cdk-playground?orgId=1&from=1728660994569&to=1728661281075) show the ALB's healthy host count never dropped below 5. That is, there was no degradation in service availability.

### Fully scaled (i.e. `desired = max`)
Before a deployment was started, the  [`scale-out` script](https://github.com/guardian/cdk-playground/blob/main/script/scale-out) was executed a few times, causing the ASG to have `min=1`, `desired=10`, `max=10`.

The [deployment](https://riffraff.code.dev-gutools.co.uk/deployment/view/3cb0a36c-9281-4b09-b4ae-325f599e738c?verbose=1) was predictably slow as it operated as a "one out, one in" update. The deployment log shows the value of the `MinInstancesInServiceForcdkplayground` CFN parameter was, expectedly, set to 7 (75% of max, rounded down):

![image](https://github.com/user-attachments/assets/b26ac64b-10dc-4c35-894e-2da004a869b1)

The [metrics](https://metrics.gutools.co.uk/d/adyqx5hf3w1s0e/cdk-playground?orgId=1&from=1729189996508&to=1729190591088) show the ALB's healthy host count dropped to 7, as expected. Whilst this results in a drop in availability, it is an unusual scenario as scaling to max is indicative of incorrect capacity planning. That is, the max should be higher.