### PR TITLE
Reference a non-existent CFN parameter in `minInstancesInServiceParameters`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           commentingStage: 'PROD'
-          configPath: cdk/cdk.out/riff-raff.yaml
+          configPath: riff-raff.yaml
           contentDirectories: |
             cdk.out:
               - cdk/cdk.out

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,39 @@
+allowedStages:
+  - PROD
+deployments:
+  # This deployment uploads the application artifact (.deb file) to S3.
+  asg-upload-eu-west-1-playground-cdk-playground:
+    type: autoscaling
+    actions:
+      - uploadArtifacts
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    parameters:
+      bucketSsmLookup: true
+      prefixApp: true
+    contentDirectory: cdk-playground
+
+  # This deployment updates the CloudFormation stack.
+  # It will start once the above deployment has completed.
+  cfn-eu-west-1-playground-cdk-playground:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - playground
+    app: cdk-playground
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        PROD: CdkPlayground.template.json
+      amiParametersToTags:
+        AMICdkplayground:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: developerPlayground-arm64-java11
+          Encrypted: 'true'
+    dependencies:
+      - asg-upload-eu-west-1-playground-cdk-playground

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -35,5 +35,8 @@ deployments:
           AmigoStage: PROD
           Recipe: developerPlayground-arm64-java11
           Encrypted: 'true'
+      minInstancesInServiceParameters:
+        DoesNotExist:
+          App: cdk-playground
     dependencies:
       - asg-upload-eu-west-1-playground-cdk-playground


### PR DESCRIPTION
## What does this change?
This is to allow testing of https://github.com/guardian/riff-raff/pull/1383 whilst the `riff-raff.yaml` generator from GuCDK hasn't been updated.

This `riff-raff.yaml` is a stripped down version of the generated one, only uploading the application artifact to S3, and deploying the application CloudFormation stack.

This is a test of behaviour when the `riff-raff.yaml` file references a CFN parameter that does not exist in the CFN template.

## How to test?
[Deploy](https://riffraff.code.dev-gutools.co.uk/deployment/view/d94845c5-102f-4980-aab1-f7906542f27f) this branch; it should fail.

![image](https://github.com/user-attachments/assets/b1a61bc1-6e97-47a3-a1eb-80525ad1043b)

> [!NOTE]
> This is existing behaviour.