### PR TITLE
feat: Configure AWS CloudWatch Agent to collect instance metrics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
               - cdk/cdk.out
             cdk-playground:
               - dist/cdk-playground
+              - amazon-cloudwatch-agent.json
             cdk-playground-lambda:
               - lambda/cdk-playground-lambda.zip
             event-forwarder:

--- a/amazon-cloudwatch-agent.json
+++ b/amazon-cloudwatch-agent.json
@@ -1,0 +1,43 @@
+{
+  "metrics": {
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}",
+      "AutoScalingGroupName":"${aws:AutoScalingGroupName}"
+    },
+    "metrics_collected": {
+      "cpu": {
+        "resources": [
+          "*"
+        ],
+        "measurement": [
+          {"name": "cpu_usage_idle", "rename": "CPU_USAGE_IDLE", "unit": "Percent"},
+          {"name": "cpu_usage_nice", "unit": "Percent"},
+          "cpu_usage_guest"
+        ],
+        "totalcpu": false
+      },
+      "disk": {
+        "resources": [
+          "*"
+        ],
+        "measurement": [
+          {"name": "free", "rename": "DISK_FREE", "unit": "Gigabytes"},
+          "total",
+          "used",
+          "used_percent"
+        ],
+        "ignore_file_system_types": [
+          "sysfs", "devtmpfs"
+        ]
+      },
+      "mem": {
+        "measurement": [
+          "available",
+          "mem_used",
+          "mem_cached",
+          "mem_total"
+        ]
+      }
+    }
+  }
+}

--- a/amazon-cloudwatch-agent.json
+++ b/amazon-cloudwatch-agent.json
@@ -1,7 +1,6 @@
 {
   "metrics": {
     "append_dimensions": {
-      "InstanceId": "${aws:InstanceId}",
       "AutoScalingGroupName":"${aws:AutoScalingGroupName}"
     },
     "metrics_collected": {

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -4,11 +4,12 @@ exports[`The Deploy stack matches the snapshot 1`] = `
 Object {
   "Metadata": Object {
     "gu:cdk:constructs": Array [
+      "GuDistributionBucketParameter",
+      "GuAllowPolicy",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
       "GuEc2AppExperimental",
-      "GuDistributionBucketParameter",
       "GuCertificate",
       "GuInstanceRole",
       "GuSsmSshPolicy",
@@ -339,6 +340,27 @@ Object {
       },
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
+    },
+    "CloudWatchAgent54BC1FED": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudWatchAgent54BC1FED",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "DescribeEC2PolicyFF5F9295": Object {
       "Properties": Object {
@@ -1694,6 +1716,14 @@ aws s3 cp 's3://",
                   },
                   "/playground/PROD/cdk-playground/cdk-playground-TEST.deb' '/cdk-playground/cdk-playground-TEST.deb'
 dpkg -i /cdk-playground/cdk-playground-TEST.deb
+mkdir -p $(dirname '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json')
+aws s3 cp 's3://",
+                  Object {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/playground/PROD/cdk-playground/amazon-cloudwatch-agent.json' '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json'
+amazon-cloudwatch-agent-ctl -a fetch-config -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+amazon-cloudwatch-agent-ctl -a start
 # GuEc2AppExperimental UserData Start
 
       TOKEN=$(curl -X PUT \\"http://169.254.169.254/latest/api/token\\" -H \\"X-aws-ec2-metadata-token-ttl-seconds: 21600\\")

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -1,15 +1,26 @@
+import path from 'node:path';
 import { GuApiLambda } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import {
+	GuDistributionBucketParameter,
+	GuStack,
+} from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration } from 'aws-cdk-lib';
 import { CfnScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
-import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import {
+	InstanceClass,
+	InstanceSize,
+	InstanceType,
+	UserData,
+} from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	/**
@@ -32,9 +43,51 @@ export class CdkPlayground extends GuStack {
 		});
 
 		const { buildIdentifier } = props;
+		const { stack, stage } = this;
 
 		const ec2App = 'cdk-playground';
 		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
+
+		const distBucket = Bucket.fromBucketAttributes(this, 'DistributionBucket', {
+			bucketName: GuDistributionBucketParameter.getInstance(this).valueAsString,
+		});
+
+		const userData = UserData.forLinux();
+
+		// Download application from S3
+		userData.addS3DownloadCommand({
+			bucket: distBucket,
+			bucketKey: path.join(
+				stack,
+				stage,
+				ec2App,
+				`${ec2App}-${buildIdentifier}.deb`,
+			),
+			localFile: `/${ec2App}/${ec2App}-${buildIdentifier}.deb`,
+		});
+
+		// Install and run application
+		userData.addCommands(`dpkg -i /${ec2App}/${ec2App}-${buildIdentifier}.deb`);
+
+		// Download the CloudWatch Agent configuration from S3
+		const cloudwatchAgentConfigPath =
+			'/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json';
+		userData.addS3DownloadCommand({
+			bucket: distBucket,
+			bucketKey: path.join(
+				stack,
+				stage,
+				ec2App,
+				'amazon-cloudwatch-agent.json',
+			),
+			localFile: cloudwatchAgentConfigPath,
+		});
+
+		// Start the CloudWatch Agent service
+		userData.addCommands(
+			`amazon-cloudwatch-agent-ctl -a fetch-config -c file:${cloudwatchAgentConfigPath}`,
+			'amazon-cloudwatch-agent-ctl -a start',
+		);
 
 		const { loadBalancer, autoScalingGroup } = new GuEc2AppExperimental(this, {
 			buildIdentifier,
@@ -42,12 +95,7 @@ export class CdkPlayground extends GuStack {
 			app: ec2App,
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 			access: { scope: AccessScope.PUBLIC },
-			userData: {
-				distributable: {
-					fileName: `${ec2App}-${buildIdentifier}.deb`,
-					executionStatement: `dpkg -i /${ec2App}/${ec2App}-${buildIdentifier}.deb`,
-				},
-			},
+			userData,
 			certificateProps: {
 				domainName: ec2AppDomainName,
 			},
@@ -61,6 +109,14 @@ export class CdkPlayground extends GuStack {
 				systemdUnitName: 'cdk-playground',
 			},
 			imageRecipe: 'developerPlayground-arm64-java11',
+			roleConfiguration: {
+				additionalPolicies: [
+					new GuAllowPolicy(this, 'CloudWatchAgent', {
+						actions: ['cloudwatch:PutMetricData'],
+						resources: ['*'],
+					}),
+				],
+			},
 		});
 
 		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {


### PR DESCRIPTION
## What does this change?
An example of configuring the AMIgo role [`aws-cloud-watch-agent`](https://github.com/guardian/amigo/tree/main/roles/aws-cloud-watch-agent).

## How to test
Deploy and observe new metrics within CloudWatch.