### PR TITLE
ci: Use `ubuntu-latest` runner and `guardian/setup-scala@v1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - main
 jobs:
   CI:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -27,14 +27,7 @@ jobs:
           cache: npm
           cache-dependency-path: 'cdk/package-lock.json'
 
-      # Java is needed for the Scala Play app
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'corretto'
-          cache: 'sbt'
-
-      - uses: sbt/setup-sbt@v1
+      - uses: guardian/setup-scala@v1
 
       # Build CDK and Play (in sequence)
       - run: ./script/ci

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-11.0.25.9.1


### PR DESCRIPTION
Inspired by https://github.com/guardian/amigo/pull/1587, this change uses the shared action to setup SBT for CI. These changes bring this repository inline with others in the organisaion.

This should resolve the slow (multi hour!) builds seen on https://github.com/guardian/cdk-playground/pull/670, which appears to be related to https://github.com/actions/runner-images/issues/11988.

<img width="1775" alt="image" src="https://github.com/user-attachments/assets/3380f7bd-9cf5-4cfc-9216-866c278d6e86" />
