### PR TITLE
feat: Enable ALB access logging

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -23,6 +23,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
+      "GuS3Bucket",
       "GuCname",
       "GuApiLambda",
       "GuCertificate",
@@ -121,6 +122,133 @@ exports[`The Deploy stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "AlbAccessLogsBucketCdkplayground1BFB689F": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "playground",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "AlbAccessLogsBucketCdkplaygroundPolicy017EB2B1": {
+      "Properties": {
+        "Bucket": {
+          "Ref": "AlbAccessLogsBucketCdkplayground1BFB689F",
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::156460612806:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "AlbAccessLogsBucketCdkplayground1BFB689F",
+                        "Arn",
+                      ],
+                    },
+                    "/playground/PROD/cdk-playground/AWSLogs/",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:PutObject",
+              "Condition": {
+                "StringEquals": {
+                  "s3:x-amz-acl": "bucket-owner-full-control",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "delivery.logs.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "AlbAccessLogsBucketCdkplayground1BFB689F",
+                        "Arn",
+                      ],
+                    },
+                    "/playground/PROD/cdk-playground/AWSLogs/",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:GetBucketAcl",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "delivery.logs.amazonaws.com",
+              },
+              "Resource": {
+                "Fn::GetAtt": [
+                  "AlbAccessLogsBucketCdkplayground1BFB689F",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "AsgRollingUpdatePolicy2A1DDC6F": {
       "Properties": {
         "PolicyDocument": {
@@ -597,6 +725,9 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
     "LoadBalancerCdkplayground7C6B4D97": {
+      "DependsOn": [
+        "AlbAccessLogsBucketCdkplaygroundPolicy017EB2B1",
+      ],
       "Properties": {
         "LoadBalancerAttributes": [
           {
@@ -610,6 +741,20 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           {
             "Key": "routing.http.drop_invalid_header_fields.enabled",
             "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AlbAccessLogsBucketCdkplayground1BFB689F",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "playground/PROD/cdk-playground",
           },
         ],
         "Scheme": "internet-facing",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -4,9 +4,10 @@ import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
-import { CfnOutput, Duration } from 'aws-cdk-lib';
+import { CfnOutput, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { CfnScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -32,6 +33,7 @@ export class CdkPlayground extends GuStack {
 		});
 
 		const { buildIdentifier } = props;
+		const { stack, stage } = this;
 
 		const ec2App = 'cdk-playground';
 		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
@@ -61,8 +63,20 @@ export class CdkPlayground extends GuStack {
 				systemdUnitName: 'cdk-playground',
 			},
 			imageRecipe: 'developerPlayground-arm64-java11',
-      instanceMetricGranularity: '5Minute'
-    });
+			instanceMetricGranularity: '5Minute',
+		});
+
+		const albAccessLogsBucket = new GuS3Bucket(this, 'AlbAccessLogsBucket', {
+			app: ec2App,
+		});
+
+		// For this app, we don't need to retain the access logs bucket after the stack is deleted.
+		albAccessLogsBucket.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+		loadBalancer.logAccessLogs(
+			albAccessLogsBucket,
+			`${stack}/${stage}/${ec2App}`,
+		);
 
 		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {
 			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,


### PR DESCRIPTION
## What does this change?
Enables ALB access logging, writing to a new S3 bucket specifically for this application. This is to aid testing the ingestion of ALB logs into the Availability Dashboard. This work is currently a spike, hence the bucket's deletion policy. If/when the spike proves successful, we'll need to think about the S3 bucket more carefully - do we have a single organisational bucket, or one per account, or one per service, etc?