### PR TITLE
feat: Ship access logs to newly created org-wide S3 bucket

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -21,9 +21,9 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       "GuHttpsEgressSecurityGroup",
       "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
-      "GuS3Bucket",
       "GuCname",
       "GuApiLambda",
       "GuCertificate",
@@ -90,6 +90,11 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       "Description": "Amazon Machine Image ID for the app cdk-playground. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
     },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
@@ -122,133 +127,6 @@ exports[`The Deploy stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "AlbAccessLogsBucketCdkplayground1BFB689F": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "PublicAccessBlockConfiguration": {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "cdk-playground",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "playground",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "AlbAccessLogsBucketCdkplaygroundPolicy017EB2B1": {
-      "Properties": {
-        "Bucket": {
-          "Ref": "AlbAccessLogsBucketCdkplayground1BFB689F",
-        },
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:PutObject",
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::156460612806:root",
-                    ],
-                  ],
-                },
-              },
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "AlbAccessLogsBucketCdkplayground1BFB689F",
-                        "Arn",
-                      ],
-                    },
-                    "/playground/PROD/cdk-playground/AWSLogs/",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    "/*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": "s3:PutObject",
-              "Condition": {
-                "StringEquals": {
-                  "s3:x-amz-acl": "bucket-owner-full-control",
-                },
-              },
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "delivery.logs.amazonaws.com",
-              },
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Fn::GetAtt": [
-                        "AlbAccessLogsBucketCdkplayground1BFB689F",
-                        "Arn",
-                      ],
-                    },
-                    "/playground/PROD/cdk-playground/AWSLogs/",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    "/*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": "s3:GetBucketAcl",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "delivery.logs.amazonaws.com",
-              },
-              "Resource": {
-                "Fn::GetAtt": [
-                  "AlbAccessLogsBucketCdkplayground1BFB689F",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
-    },
     "AsgRollingUpdatePolicy2A1DDC6F": {
       "Properties": {
         "PolicyDocument": {
@@ -725,9 +603,6 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
     "LoadBalancerCdkplayground7C6B4D97": {
-      "DependsOn": [
-        "AlbAccessLogsBucketCdkplaygroundPolicy017EB2B1",
-      ],
       "Properties": {
         "LoadBalancerAttributes": [
           {
@@ -749,12 +624,12 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           {
             "Key": "access_logs.s3.bucket",
             "Value": {
-              "Ref": "AlbAccessLogsBucketCdkplayground1BFB689F",
+              "Ref": "AccessLoggingBucket",
             },
           },
           {
             "Key": "access_logs.s3.prefix",
-            "Value": "playground/PROD/cdk-playground",
+            "Value": "v2/PROD/playground/cdk-playground",
           },
         ],
         "Scheme": "internet-facing",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -4,10 +4,9 @@ import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
-import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
-import { CfnOutput, Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnOutput, Duration } from 'aws-cdk-lib';
 import { CfnScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -64,19 +63,11 @@ export class CdkPlayground extends GuStack {
 			},
 			imageRecipe: 'developerPlayground-arm64-java11',
 			instanceMetricGranularity: '5Minute',
+			accessLogging: {
+				enabled: true,
+				prefix: `v2/${stage}/${stack}/${ec2App}`,
+			},
 		});
-
-		const albAccessLogsBucket = new GuS3Bucket(this, 'AlbAccessLogsBucket', {
-			app: ec2App,
-		});
-
-		// For this app, we don't need to retain the access logs bucket after the stack is deleted.
-		albAccessLogsBucket.applyRemovalPolicy(RemovalPolicy.DESTROY);
-
-		loadBalancer.logAccessLogs(
-			albAccessLogsBucket,
-			`${stack}/${stage}/${ec2App}`,
-		);
 
 		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {
 			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,


### PR DESCRIPTION
## What does this change?
Updates the changes in https://github.com/guardian/cdk-playground/pull/721 following https://github.com/guardian/aws-account-setup/pull/345 which created an org-wide S3 bucket.

> [!NOTE]
> This change removes an S3 bucket, therefore would need to be deployed "dangerously" in Riff-Raff.