### PR TITLE
feat: Move infrastructure from playground account to deployTools account

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,9 +1,10 @@
 import 'source-map-support/register';
-import { GuRoot } from '@guardian/cdk/lib/constructs/root';
+import { RiffRaffYamlFile } from '@guardian/cdk/lib/riff-raff-yaml-file';
+import { App } from 'aws-cdk-lib';
 import { CdkPlayground } from '../lib/cdk-playground';
 import { EventForwarder } from '../lib/event-forwarder';
 
-const app = new GuRoot();
+const app = new App();
 
 const eventForwarder = new EventForwarder(app);
 
@@ -14,3 +15,37 @@ const applicationStack = new CdkPlayground(app, 'CdkPlayground', {
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.
 applicationStack.addDependency(eventForwarder);
+
+const riffRaff = new RiffRaffYamlFile(app);
+const cfnDeployment = riffRaff.riffRaffYaml.deployments.get(
+	'cfn-eu-west-1-deploy-cdk-playground',
+);
+
+/*
+Required only for the initial deployment.
+
+The cdk-playground stack has a CFN parameter `MinInstancesInServiceForcdkplayground` that does not have a default value.
+We have to provide the initial value.
+
+There are a few ways to do this:
+- Create the CFN stack manually in the AWS console and provide the value
+- Set the CFN parameter `riff-raff.yaml` and use Riff-Raff to deploy the stack
+- Set the value in the cdk-playground stack
+
+The latter is tricky, as the parameter is added via an Aspect, which is not executed within the `constructor` of CdkPlayground,
+we'd have to find the relevant CDK hook.
+
+Below, we set the value in the `riff-raff.yaml` file.
+ */
+if (cfnDeployment) {
+	cfnDeployment.parameters = {
+		...cfnDeployment.parameters,
+		templateStageParameters: {
+			PROD: {
+				MinInstancesInServiceForcdkplayground: '1',
+			},
+		},
+	};
+}
+
+riffRaff.synth();

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -8,7 +8,7 @@ const app = new GuRoot();
 const eventForwarder = new EventForwarder(app);
 
 const applicationStack = new CdkPlayground(app, 'CdkPlayground', {
-	cloudFormationStackName: 'playground-PROD-cdk-playground',
+	cloudFormationStackName: 'deploy-PROD-cdk-playground',
 	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 });
 

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -1,6 +1,6 @@
 {
   "app": "npx ts-node bin/cdk.ts",
-  "profile": "developerPlayground",
+  "profile": "deploy",
   "context": {
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true"

--- a/cdk/event-forwarder/.env
+++ b/cdk/event-forwarder/.env
@@ -1,3 +1,3 @@
-STACK=playground
+STACK=deploy
 STAGE=DEV
 APP=event-forwarder

--- a/cdk/event-forwarder/index.ts
+++ b/cdk/event-forwarder/index.ts
@@ -60,7 +60,7 @@ async function getCloudformationStackNameForAsg(
 	const awsConfig: AwsClientConfig = {
 		region: 'eu-west-1',
 		...(stage === 'DEV' && {
-			credentials: fromIni({ profile: 'developerPlayground' }),
+			credentials: fromIni({ profile: 'deploy' }),
 		}),
 	};
 

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -171,11 +171,11 @@ exports[`The Deploy stack matches the snapshot 1`] = `
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
           "LaunchTemplateId": {
-            "Ref": "playgroundPRODcdkplayground7B64111F",
+            "Ref": "deployPRODcdkplayground4155738F",
           },
           "Version": {
             "Fn::GetAtt": [
-              "playgroundPRODcdkplayground7B64111F",
+              "deployPRODcdkplayground4155738F",
               "LatestVersionNumber",
             ],
           },
@@ -213,7 +213,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           {
             "Key": "Stack",
             "PropagateAtLaunch": true,
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -296,7 +296,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -331,7 +331,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -401,7 +401,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
                     {
                       "Ref": "DistributionBucketName",
                     },
-                    "/playground/PROD/cdk-playground/*",
+                    "/deploy/PROD/cdk-playground/*",
                   ],
                 ],
               },
@@ -445,7 +445,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -547,7 +547,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -627,7 +627,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "access_logs.s3.prefix",
-            "Value": "application-load-balancer/PROD/playground/cdk-playground",
+            "Value": "application-load-balancer/PROD/deploy/cdk-playground",
           },
         ],
         "Scheme": "internet-facing",
@@ -657,7 +657,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -695,7 +695,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -744,7 +744,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/playground/cdk-playground",
+                    ":parameter/PROD/deploy/cdk-playground",
                   ],
                 ],
               },
@@ -763,7 +763,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/playground/cdk-playground/*",
+                    ":parameter/PROD/deploy/cdk-playground/*",
                   ],
                 ],
               },
@@ -840,7 +840,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -865,6 +865,208 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
+    "deployPRODcdkplayground4155738F": {
+      "DependsOn": [
+        "InstanceRoleCdkplaygroundC280027A",
+      ],
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployPRODcdkplaygroundProfile5822B7A8",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMICdkplayground",
+          },
+          "InstanceType": "t4g.micro",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
+          },
+          "Monitoring": {
+            "Enabled": false,
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "cdk-playground",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk-playground",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CdkPlayground/deploy-PROD-cdk-playground",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "cdk-playground",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk-playground",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CdkPlayground/deploy-PROD-cdk-playground",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "PROD",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupCdkplaygroundASGD6E49F0F           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
+mkdir -p $(dirname '/cdk-playground/cdk-playground-TEST.deb')
+aws s3 cp 's3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/PROD/cdk-playground/cdk-playground-TEST.deb' '/cdk-playground/cdk-playground-TEST.deb'
+dpkg -i /cdk-playground/cdk-playground-TEST.deb
+# GuEc2AppExperimental Instance Health Check Start
+
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance running build TEST is healthy in target group."
+      
+# GuEc2AppExperimental Instance Health Check End",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "App",
+                "Value": "cdk-playground",
+              },
+              {
+                "Key": "gu:build-identifier",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk-playground",
+              },
+              {
+                "Key": "Name",
+                "Value": "CdkPlayground/deploy-PROD-cdk-playground",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "PROD",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployPRODcdkplaygroundProfile5822B7A8": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
     "lambda8B5974B5": {
       "DependsOn": [
         "lambdaServiceRoleDefaultPolicyBF6FA5E7",
@@ -875,12 +1077,12 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "playground/PROD/cdk-playground-lambda/cdk-playground-lambda.zip",
+          "S3Key": "deploy/PROD/cdk-playground-lambda/cdk-playground-lambda.zip",
         },
         "Environment": {
           "Variables": {
             "APP": "cdk-playground-lambda",
-            "STACK": "playground",
+            "STACK": "deploy",
             "STAGE": "PROD",
           },
         },
@@ -911,7 +1113,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -965,7 +1167,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -1014,7 +1216,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/playground/PROD/cdk-playground-lambda/cdk-playground-lambda.zip",
+                      "/deploy/PROD/cdk-playground-lambda/cdk-playground-lambda.zip",
                     ],
                   ],
                 },
@@ -1031,7 +1233,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/playground/cdk-playground-lambda",
+                    ":parameter/PROD/deploy/cdk-playground-lambda",
                   ],
                 ],
               },
@@ -1050,7 +1252,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/playground/cdk-playground-lambda/*",
+                    ":parameter/PROD/deploy/cdk-playground-lambda/*",
                   ],
                 ],
               },
@@ -1070,7 +1272,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
     "lambdacdkplaygroundlambdaapi061BB942": {
       "Properties": {
         "Description": "cdk-playground-lambda",
-        "Name": "playground-PROD-cdk-playground-lambda-api",
+        "Name": "deploy-PROD-cdk-playground-lambda-api",
         "Tags": [
           {
             "Key": "App",
@@ -1086,7 +1288,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -1265,7 +1467,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -1276,7 +1478,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "lambdacdkplaygroundlambdaapiDeployment157471B23507d885fa4f6f2bfbd1011b60b24ca1": {
+    "lambdacdkplaygroundlambdaapiDeployment157471B20d2d4164f37ebcfcd963e39b83d9cd68": {
       "DependsOn": [
         "lambdacdkplaygroundlambdaapiproxyANYDB984CB2",
         "lambdacdkplaygroundlambdaapiproxyFA4DE6D2",
@@ -1296,7 +1498,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "lambdacdkplaygroundlambdaapiDeployment157471B23507d885fa4f6f2bfbd1011b60b24ca1",
+          "Ref": "lambdacdkplaygroundlambdaapiDeployment157471B20d2d4164f37ebcfcd963e39b83d9cd68",
         },
         "RestApiId": {
           "Ref": "lambdacdkplaygroundlambdaapi061BB942",
@@ -1317,7 +1519,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -1353,7 +1555,7 @@ exports[`The Deploy stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -1497,208 +1699,6 @@ exports[`The Deploy stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::ApiGateway::Resource",
-    },
-    "playgroundPRODcdkplayground7B64111F": {
-      "DependsOn": [
-        "InstanceRoleCdkplaygroundC280027A",
-      ],
-      "Properties": {
-        "LaunchTemplateData": {
-          "IamInstanceProfile": {
-            "Arn": {
-              "Fn::GetAtt": [
-                "playgroundPRODcdkplaygroundProfile617BB4EE",
-                "Arn",
-              ],
-            },
-          },
-          "ImageId": {
-            "Ref": "AMICdkplayground",
-          },
-          "InstanceType": "t4g.micro",
-          "MetadataOptions": {
-            "HttpTokens": "required",
-            "InstanceMetadataTags": "enabled",
-          },
-          "Monitoring": {
-            "Enabled": false,
-          },
-          "SecurityGroupIds": [
-            {
-              "Fn::GetAtt": [
-                "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
-                "GroupId",
-              ],
-            },
-          ],
-          "TagSpecifications": [
-            {
-              "ResourceType": "instance",
-              "Tags": [
-                {
-                  "Key": "App",
-                  "Value": "cdk-playground",
-                },
-                {
-                  "Key": "gu:build-identifier",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:cdk:version",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:repo",
-                  "Value": "guardian/cdk-playground",
-                },
-                {
-                  "Key": "Name",
-                  "Value": "CdkPlayground/playground-PROD-cdk-playground",
-                },
-                {
-                  "Key": "Stack",
-                  "Value": "playground",
-                },
-                {
-                  "Key": "Stage",
-                  "Value": "PROD",
-                },
-              ],
-            },
-            {
-              "ResourceType": "volume",
-              "Tags": [
-                {
-                  "Key": "App",
-                  "Value": "cdk-playground",
-                },
-                {
-                  "Key": "gu:build-identifier",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:cdk:version",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:repo",
-                  "Value": "guardian/cdk-playground",
-                },
-                {
-                  "Key": "Name",
-                  "Value": "CdkPlayground/playground-PROD-cdk-playground",
-                },
-                {
-                  "Key": "Stack",
-                  "Value": "playground",
-                },
-                {
-                  "Key": "Stage",
-                  "Value": "PROD",
-                },
-              ],
-            },
-          ],
-          "UserData": {
-            "Fn::Base64": {
-              "Fn::Join": [
-                "",
-                [
-                  "#!/bin/bash
-function exitTrap(){
-exitCode=$?
-
-        cfn-signal --stack ",
-                  {
-                    "Ref": "AWS::StackId",
-                  },
-                  "           --resource AutoScalingGroupCdkplaygroundASGD6E49F0F           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
-        
-}
-trap exitTrap EXIT
-mkdir -p $(dirname '/cdk-playground/cdk-playground-TEST.deb')
-aws s3 cp 's3://",
-                  {
-                    "Ref": "DistributionBucketName",
-                  },
-                  "/playground/PROD/cdk-playground/cdk-playground-TEST.deb' '/cdk-playground/cdk-playground-TEST.deb'
-dpkg -i /cdk-playground/cdk-playground-TEST.deb
-# GuEc2AppExperimental Instance Health Check Start
-
-      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
-
-      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
-                  {
-                    "Ref": "TargetGroupCdkplayground7A453FC2",
-                  },
-                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
-
-      until [ "$STATE" == "\\"healthy\\"" ]; do
-        echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
-        sleep 5
-        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
-                  {
-                    "Ref": "TargetGroupCdkplayground7A453FC2",
-                  },
-                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
-      done
-
-      echo "Instance running build TEST is healthy in target group."
-      
-# GuEc2AppExperimental Instance Health Check End",
-                ],
-              ],
-            },
-          },
-        },
-        "TagSpecifications": [
-          {
-            "ResourceType": "launch-template",
-            "Tags": [
-              {
-                "Key": "App",
-                "Value": "cdk-playground",
-              },
-              {
-                "Key": "gu:build-identifier",
-                "Value": "TEST",
-              },
-              {
-                "Key": "gu:cdk:version",
-                "Value": "TEST",
-              },
-              {
-                "Key": "gu:repo",
-                "Value": "guardian/cdk-playground",
-              },
-              {
-                "Key": "Name",
-                "Value": "CdkPlayground/playground-PROD-cdk-playground",
-              },
-              {
-                "Key": "Stack",
-                "Value": "playground",
-              },
-              {
-                "Key": "Stage",
-                "Value": "PROD",
-              },
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::EC2::LaunchTemplate",
-    },
-    "playgroundPRODcdkplaygroundProfile617BB4EE": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
+++ b/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`The EventForwarder stack matches the snapshot 1`] = `
 {
@@ -137,12 +137,12 @@ exports[`The EventForwarder stack matches the snapshot 1`] = `
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "playground/PROD/event-forwarder/event-forwarder.zip",
+          "S3Key": "deploy/PROD/event-forwarder/event-forwarder.zip",
         },
         "Environment": {
           "Variables": {
             "APP": "event-forwarder",
-            "STACK": "playground",
+            "STACK": "deploy",
             "STAGE": "PROD",
           },
         },
@@ -173,7 +173,7 @@ exports[`The EventForwarder stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -227,7 +227,7 @@ exports[`The EventForwarder stack matches the snapshot 1`] = `
           },
           {
             "Key": "Stack",
-            "Value": "playground",
+            "Value": "deploy",
           },
           {
             "Key": "Stage",
@@ -276,7 +276,7 @@ exports[`The EventForwarder stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/playground/PROD/event-forwarder/event-forwarder.zip",
+                      "/deploy/PROD/event-forwarder/event-forwarder.zip",
                     ],
                   ],
                 },
@@ -293,7 +293,7 @@ exports[`The EventForwarder stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/playground/event-forwarder",
+                    ":parameter/PROD/deploy/event-forwarder",
                   ],
                 ],
               },
@@ -312,7 +312,7 @@ exports[`The EventForwarder stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/PROD/playground/event-forwarder/*",
+                    ":parameter/PROD/deploy/event-forwarder/*",
                   ],
                 ],
               },

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -26,7 +26,7 @@ export class CdkPlayground extends GuStack {
 	constructor(scope: App, id: string, props: CdkPlaygroundProps) {
 		super(scope, id, {
 			...props,
-			stack: 'playground',
+			stack: 'deploy',
 			stage: 'PROD',
 			env: { region: 'eu-west-1' },
 		});
@@ -61,7 +61,7 @@ export class CdkPlayground extends GuStack {
 				enabled: true,
 				systemdUnitName: 'cdk-playground',
 			},
-			imageRecipe: 'developerPlayground-arm64-java11',
+			imageRecipe: 'arm64-focal-java11-deploy-infrastructure',
 			instanceMetricGranularity: '5Minute',
 			accessLogging: {
 				enabled: true,

--- a/cdk/lib/event-forwarder.ts
+++ b/cdk/lib/event-forwarder.ts
@@ -12,7 +12,7 @@ export class EventForwarder extends GuStack {
 		const app = 'event-forwarder';
 
 		super(scope, 'EventForwarder', {
-			stack: 'playground',
+			stack: 'deploy',
 			stage: 'PROD',
 			app,
 			env: {

--- a/script/scale-in
+++ b/script/scale-in
@@ -2,12 +2,12 @@
 
 set -e
 
-CLOUDFORMATION_STACK_NAME=playground-PROD-cdk-playground
+CLOUDFORMATION_STACK_NAME=deploy-PROD-cdk-playground
 
 POLICY_ARN=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile developerPlayground \
+      --profile deploy \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleInArn") ] | any) | .OutputValue'
@@ -16,7 +16,7 @@ POLICY_ARN=$(
 ASG_NAME=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile developerPlayground \
+      --profile deploy \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
@@ -25,20 +25,20 @@ ASG_NAME=$(
 CURRENT_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile developerPlayground \
+    --profile deploy \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )
 
 aws autoscaling execute-policy \
   --policy-name "$POLICY_ARN" \
-  --profile developerPlayground \
+  --profile deploy \
   --region eu-west-1
 
 NEW_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile developerPlayground \
+    --profile deploy \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )

--- a/script/scale-out
+++ b/script/scale-out
@@ -2,12 +2,12 @@
 
 set -e
 
-CLOUDFORMATION_STACK_NAME=playground-PROD-cdk-playground
+CLOUDFORMATION_STACK_NAME=deploy-PROD-cdk-playground
 
 POLICY_ARN=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile developerPlayground \
+      --profile deploy \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleOutArn") ] | any) | .OutputValue'
@@ -16,7 +16,7 @@ POLICY_ARN=$(
 ASG_NAME=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile developerPlayground \
+      --profile deploy \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
@@ -25,20 +25,20 @@ ASG_NAME=$(
 CURRENT_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile developerPlayground \
+    --profile deploy \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )
 
 aws autoscaling execute-policy \
   --policy-name "$POLICY_ARN" \
-  --profile developerPlayground \
+  --profile deploy \
   --region eu-west-1
 
 NEW_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile developerPlayground \
+    --profile deploy \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )


### PR DESCRIPTION
## What does this change?
The playground isn't suited for long-lived projects, which this is. Switch to the deployTools account as DevX own this service. To achieve this, the `stack` value switches from `playground` to `deploy`.

### Deployment plan
The domain name (`cdk-playground.gutools.co.uk`) isn't being updated, therefore to deploy:
- [x] Delete the CloudFormation stacks in the playground account
- [x] [Deploy this branch](https://riffraff.gutools.co.uk/deployment/view/6b347bab-9a30-4c24-af3b-cbc2ec9871ea)

## How to test
I don't think it's possible to test this it requires removing and recreating infrastructure.

## How can we measure success?
Ultimately `cdk-playground.gutools.co.uk` still returns content. Indeed https://cdk-playground.gutools.co.uk/tags should show the `Stack` tag having value `deploy`.

At a DNS level the CNAME should point to a new location. Currently, it is this:

```console
❯ dig +short cdk-playground.gutools.co.uk
playg-loadb-eieho3l6xpad-1330756013.eu-west-1.elb.amazonaws.com.
```

## Have we considered potential risks?
There isn't any. This app is for the DevX teams use - there are no other consumers. Additionally, the app holds no state.
