### PR TITLE
feat(cdk): Create a CODE stage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,6 @@ jobs:
           projectName: devx::cdk-playground
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          commentingStage: 'PROD'
           configPath: cdk/cdk.out/riff-raff.yaml
           contentDirectories: |
             cdk.out:

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,11 +6,14 @@ import { EventForwarder } from '../lib/event-forwarder';
 
 const app = new App();
 
-const eventForwarder = new EventForwarder(app, 'EventForwarder', {
+const eventForwarderProd = new EventForwarder(app, 'EventForwarder', {
 	stage: 'PROD',
 });
+const eventForwarderCode = new EventForwarder(app, 'EventForwarder-CODE', {
+	stage: 'CODE',
+});
 
-const applicationStack = new CdkPlayground(app, 'CdkPlayground', {
+const applicationStackProd = new CdkPlayground(app, 'CdkPlayground', {
 	cloudFormationStackName: 'deploy-PROD-cdk-playground',
 	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 	stage: 'PROD',
@@ -18,8 +21,17 @@ const applicationStack = new CdkPlayground(app, 'CdkPlayground', {
 	lambdaDomainName: 'cdk-playground-lambda.gutools.co.uk',
 });
 
+const applicationStackCode = new CdkPlayground(app, 'CdkPlayground-CODE', {
+	cloudFormationStackName: 'deploy-CODE-cdk-playground',
+	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+	stage: 'CODE',
+	ec2AppDomainName: 'cdk-playground.code.dev-gutools.co.uk',
+	lambdaDomainName: 'cdk-playground-lambda.code.dev-gutools.co.uk',
+});
+
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.
-applicationStack.addDependency(eventForwarder);
+applicationStackProd.addDependency(eventForwarderProd);
+applicationStackCode.addDependency(eventForwarderCode);
 
 const riffRaff = new RiffRaffYamlFile(app);
 const cfnDeployment = riffRaff.riffRaffYaml.deployments.get(
@@ -47,6 +59,9 @@ if (cfnDeployment) {
 		...cfnDeployment.parameters,
 		templateStageParameters: {
 			PROD: {
+				MinInstancesInServiceForcdkplayground: '1',
+			},
+			CODE: {
 				MinInstancesInServiceForcdkplayground: '1',
 			},
 		},

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,11 +6,16 @@ import { EventForwarder } from '../lib/event-forwarder';
 
 const app = new App();
 
-const eventForwarder = new EventForwarder(app);
+const eventForwarder = new EventForwarder(app, 'EventForwarder', {
+	stage: 'PROD',
+});
 
 const applicationStack = new CdkPlayground(app, 'CdkPlayground', {
 	cloudFormationStackName: 'deploy-PROD-cdk-playground',
 	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+	stage: 'PROD',
+	ec2AppDomainName: 'cdk-playground.gutools.co.uk',
+	lambdaDomainName: 'cdk-playground-lambda.gutools.co.uk',
 });
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -1703,3 +1703,1707 @@ dpkg -i /cdk-playground/cdk-playground-TEST.deb
   },
 }
 `;
+
+exports[`The Deploy stack matches the snapshot for CODE 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuVpcParameter",
+      "GuSubnetListParameter",
+      "GuSubnetListParameter",
+      "GuEc2AppExperimental",
+      "GuDistributionBucketParameter",
+      "GuCertificate",
+      "GuInstanceRole",
+      "GuSsmSshPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuAmiParameter",
+      "GuHttpsEgressSecurityGroup",
+      "GuAutoScalingGroup",
+      "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
+      "GuApplicationTargetGroup",
+      "GuHttpsApplicationListener",
+      "GuCname",
+      "GuApiLambda",
+      "GuCertificate",
+      "GuCname",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "AutoscalingGroupName": {
+      "Value": {
+        "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
+      },
+    },
+    "LoadBalancerCdkplaygroundDnsName": {
+      "Description": "DNS entry for LoadBalancerCdkplayground",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerCdkplayground7C6B4D97",
+          "DNSName",
+        ],
+      },
+    },
+    "ScaleInArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "AutoScalingGroupCdkplaygroundScaleIn24F0C6B8",
+          "Arn",
+        ],
+      },
+    },
+    "ScaleOutArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "AutoScalingGroupCdkplaygroundScaleOutA06BF2EE",
+          "Arn",
+        ],
+      },
+    },
+    "lambdacdkplaygroundlambdaapiEndpoint0E1DFC5F": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+            },
+            ".execute-api.eu-west-1.",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "lambdacdkplaygroundlambdaapiDeploymentStageprod4C07895E",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "AMICdkplayground": {
+      "Description": "Amazon Machine Image ID for the app cdk-playground. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "MinInstancesInServiceForcdkplayground": {
+      "Type": "Number",
+    },
+    "VpcId": {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "cdkplaygroundPrivateSubnets": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "cdkplaygroundPublicSubnets": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+  },
+  "Resources": {
+    "AsgRollingUpdatePolicy2A1DDC6F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudformation:SignalResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AWS::StackId",
+              },
+            },
+            {
+              "Action": "elasticloadbalancing:DescribeTargetHealth",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "AutoScalingGroupCdkplaygroundASGD6E49F0F": {
+      "CreationPolicy": {
+        "AutoScalingCreationPolicy": {
+          "MinSuccessfulInstancesPercent": 100,
+        },
+        "ResourceSignal": {
+          "Count": 1,
+          "Timeout": "PT3M",
+        },
+      },
+      "DependsOn": [
+        "AsgRollingUpdatePolicy2A1DDC6F",
+      ],
+      "Properties": {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "deployCODEcdkplaygroundCA0A63B1",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "deployCODEcdkplaygroundCA0A63B1",
+              "LatestVersionNumber",
+            ],
+          },
+        },
+        "MaxSize": "10",
+        "MetricsCollection": [
+          {
+            "Granularity": "1Minute",
+          },
+        ],
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "CODE",
+          },
+          {
+            "Key": "SystemdUnit",
+            "PropagateAtLaunch": true,
+            "Value": "cdk-playground.service",
+          },
+        ],
+        "TargetGroupARNs": [
+          {
+            "Ref": "TargetGroupCdkplayground7A453FC2",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "cdkplaygroundPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingRollingUpdate": {
+          "MaxBatchSize": 10,
+          "MinInstancesInService": {
+            "Ref": "MinInstancesInServiceForcdkplayground",
+          },
+          "MinSuccessfulInstancesPercent": 100,
+          "PauseTime": "PT3M",
+          "SuspendProcesses": [
+            "AlarmNotification",
+          ],
+          "WaitOnResourceSignals": true,
+        },
+      },
+    },
+    "AutoScalingGroupCdkplaygroundScaleIn24F0C6B8": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": -1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "AutoScalingGroupCdkplaygroundScaleOutA06BF2EE": {
+      "Properties": {
+        "AdjustmentType": "ChangeInCapacity",
+        "AutoScalingGroupName": {
+          "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
+        },
+        "PolicyType": "SimpleScaling",
+        "ScalingAdjustment": 1,
+      },
+      "Type": "AWS::AutoScaling::ScalingPolicy",
+    },
+    "CertificateCdkplayground47FCF7D9": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "cdk-playground.code.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Name",
+            "Value": "CdkPlayground-CODE/CertificateCdkplayground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CertificateCdkplaygroundlambda82D0BE4D": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "cdk-playground-lambda.code.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Name",
+            "Value": "CdkPlayground-CODE/CertificateCdkplaygroundlambda",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "DescribeEC2PolicyFF5F9295": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "EC2AppDNS": {
+      "Properties": {
+        "Name": "cdk-playground.code.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerCdkplayground7C6B4D97",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "CODE",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "GetDistributablePolicyCdkplaygroundBFB4D02B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/deploy/CODE/cdk-playground/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyCdkplaygroundBFB4D02B",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupCdkplaygroundfromCdkPlaygroundCODELoadBalancerCdkplaygroundSecurityGroup0DBDF6109000EA378CBA": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleCdkplaygroundC280027A": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LambdaDNS": {
+      "Properties": {
+        "Name": "cdk-playground-lambda.code.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "lambdacdkplaygroundlambdaapidomainD1A8D46F",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "Stage": "CODE",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "ListenerCdkplaygroundA8D9CA6F": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateCdkplayground47FCF7D9",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupCdkplayground7A453FC2",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerCdkplayground7C6B4D97",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerCdkplayground7C6B4D97": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/CODE/deploy/cdk-playground",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "cdkplaygroundPublicSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundCODELoadBalancerCdkplaygroundACDA30E1",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEGuHttpsEgressSecurityGroupCdkplayground610B4DD790000DEACC63": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ParameterStoreReadCdkplaygroundF78958B9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SsmSshPolicy4CFC977E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-ssh-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupCdkplayground7A453FC2": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "deployCODEcdkplaygroundCA0A63B1": {
+      "DependsOn": [
+        "InstanceRoleCdkplaygroundC280027A",
+      ],
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployCODEcdkplaygroundProfileF02041A0",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMICdkplayground",
+          },
+          "InstanceType": "t4g.micro",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+            "InstanceMetadataTags": "enabled",
+          },
+          "Monitoring": {
+            "Enabled": false,
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "cdk-playground",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk-playground",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CdkPlayground-CODE/deploy-CODE-cdk-playground",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "CODE",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "App",
+                  "Value": "cdk-playground",
+                },
+                {
+                  "Key": "gu:build-identifier",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/cdk-playground",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CdkPlayground-CODE/deploy-CODE-cdk-playground",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "CODE",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupCdkplaygroundASGD6E49F0F           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
+mkdir -p $(dirname '/cdk-playground/cdk-playground-TEST.deb')
+aws s3 cp 's3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/CODE/cdk-playground/cdk-playground-TEST.deb' '/cdk-playground/cdk-playground-TEST.deb'
+dpkg -i /cdk-playground/cdk-playground-TEST.deb
+# GuEc2AppExperimental Instance Health Check Start
+
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance running build TEST is healthy in target group."
+      
+# GuEc2AppExperimental Instance Health Check End",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "App",
+                "Value": "cdk-playground",
+              },
+              {
+                "Key": "gu:build-identifier",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/cdk-playground",
+              },
+              {
+                "Key": "Name",
+                "Value": "CdkPlayground-CODE/deploy-CODE-cdk-playground",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "CODE",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployCODEcdkplaygroundProfileF02041A0": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "lambda8B5974B5": {
+      "DependsOn": [
+        "lambdaServiceRoleDefaultPolicyBF6FA5E7",
+        "lambdaServiceRole494E4CA6",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/CODE/cdk-playground-lambda/cdk-playground-lambda.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "cdk-playground-lambda",
+            "STACK": "deploy",
+            "STAGE": "CODE",
+          },
+        },
+        "Handler": "handler.main",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "lambdaServiceRole494E4CA6",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "lambdaServiceRole494E4CA6": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "lambdaServiceRoleDefaultPolicyBF6FA5E7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/CODE/cdk-playground-lambda/cdk-playground-lambda.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-lambda",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-lambda/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "lambdaServiceRoleDefaultPolicyBF6FA5E7",
+        "Roles": [
+          {
+            "Ref": "lambdaServiceRole494E4CA6",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "lambdacdkplaygroundlambdaapi061BB942": {
+      "Properties": {
+        "Description": "cdk-playground-lambda",
+        "Name": "deploy-CODE-cdk-playground-lambda-api",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "lambdacdkplaygroundlambdaapiANY46D7365E": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "lambda8B5974B5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "lambdacdkplaygroundlambdaapi061BB942",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": {
+          "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "lambdacdkplaygroundlambdaapiANYApiPermissionCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYC109836E": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+              },
+              "/",
+              {
+                "Ref": "lambdacdkplaygroundlambdaapiDeploymentStageprod4C07895E",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdacdkplaygroundlambdaapiANYApiPermissionTestCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYB41263D8": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdacdkplaygroundlambdaapiAccount6891AB06": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "lambdacdkplaygroundlambdaapi061BB942",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "lambdacdkplaygroundlambdaapiCloudWatchRole4B1F446E",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "lambdacdkplaygroundlambdaapiCloudWatchRole4B1F446E": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "lambdacdkplaygroundlambdaapiDeployment157471B28266d1e345dae549af9ec84edc7f0bc3": {
+      "DependsOn": [
+        "lambdacdkplaygroundlambdaapiproxyANYDB984CB2",
+        "lambdacdkplaygroundlambdaapiproxyFA4DE6D2",
+        "lambdacdkplaygroundlambdaapiANY46D7365E",
+      ],
+      "Properties": {
+        "Description": "cdk-playground-lambda",
+        "RestApiId": {
+          "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "lambdacdkplaygroundlambdaapiDeploymentStageprod4C07895E": {
+      "DependsOn": [
+        "lambdacdkplaygroundlambdaapiAccount6891AB06",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "lambdacdkplaygroundlambdaapiDeployment157471B28266d1e345dae549af9ec84edc7f0bc3",
+        },
+        "RestApiId": {
+          "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "lambdacdkplaygroundlambdaapidomainD1A8D46F": {
+      "Properties": {
+        "DomainName": "cdk-playground-lambda.code.dev-gutools.co.uk",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Ref": "CertificateCdkplaygroundlambda82D0BE4D",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "lambdacdkplaygroundlambdaapidomainMapCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8E22B777C": {
+      "Properties": {
+        "DomainName": {
+          "Ref": "lambdacdkplaygroundlambdaapidomainD1A8D46F",
+        },
+        "RestApiId": {
+          "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+        },
+        "Stage": {
+          "Ref": "lambdacdkplaygroundlambdaapiDeploymentStageprod4C07895E",
+        },
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping",
+    },
+    "lambdacdkplaygroundlambdaapiproxyANYApiPermissionCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYproxyD3A0C3C8": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+              },
+              "/",
+              {
+                "Ref": "lambdacdkplaygroundlambdaapiDeploymentStageprod4C07895E",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdacdkplaygroundlambdaapiproxyANYApiPermissionTestCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYproxyD0C7A195": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "lambda8B5974B5",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "lambdacdkplaygroundlambdaapiproxyANYDB984CB2": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "lambda8B5974B5",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": {
+          "Ref": "lambdacdkplaygroundlambdaapiproxyFA4DE6D2",
+        },
+        "RestApiId": {
+          "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "lambdacdkplaygroundlambdaapiproxyFA4DE6D2": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "lambdacdkplaygroundlambdaapi061BB942",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+  },
+}
+`;

--- a/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
+++ b/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
@@ -337,3 +337,341 @@ exports[`The EventForwarder stack matches the snapshot 1`] = `
   },
 }
 `;
+
+exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuLambdaFunction",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "AutoscalingGroupEventForwarderRuleAllowEventRuleEventForwarderCODEEventForwarderLambda1F8FAB60FA8C1744": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "EventForwarderLambda9F6516CF",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "AutoscalingGroupEventForwarderRuleE7A6B6BF",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "AutoscalingGroupEventForwarderRuleE7A6B6BF": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "AutoScalingGroupName": [
+              {
+                "wildcard": "playground-PROD-cdk-playground-*",
+              },
+            ],
+          },
+          "source": [
+            "aws.autoscaling",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "EventForwarderLambda9F6516CF",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudformationEventForwarderRuleAllowEventRuleEventForwarderCODEEventForwarderLambda1F8FAB60F64CD23A": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "EventForwarderLambda9F6516CF",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "CloudformationEventForwarderRuleD95AAF62",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "CloudformationEventForwarderRuleD95AAF62": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "stack-id": [
+              {
+                "wildcard": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:aws:cloudformation:eu-west-1:",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/playground-PROD-cdk-playground*",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          "detail-type": [
+            "CloudFormation Resource Status Change",
+          ],
+          "source": [
+            "aws.cloudformation",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "EventForwarderLambda9F6516CF",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "EventForwarderLambda9F6516CF": {
+      "DependsOn": [
+        "EventForwarderLambdaServiceRoleDefaultPolicy5D01F634",
+        "EventForwarderLambdaServiceRole25D27763",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/CODE/event-forwarder/event-forwarder.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "event-forwarder",
+            "STACK": "deploy",
+            "STAGE": "CODE",
+          },
+        },
+        "Handler": "index.main",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "EventForwarderLambdaServiceRole25D27763",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "event-forwarder",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "EventForwarderLambdaServiceRole25D27763": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "event-forwarder",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EventForwarderLambdaServiceRoleDefaultPolicy5D01F634": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/CODE/event-forwarder/event-forwarder.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/event-forwarder",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/event-forwarder/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "autoscaling:DescribeAutoScalingGroups",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EventForwarderLambdaServiceRoleDefaultPolicy5D01F634",
+        "Roles": [
+          {
+            "Ref": "EventForwarderLambdaServiceRole25D27763",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+  },
+}
+`;

--- a/cdk/lib/cdk-playground.test.ts
+++ b/cdk/lib/cdk-playground.test.ts
@@ -7,6 +7,9 @@ describe('The Deploy stack', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlayground(app, 'CdkPlayground', {
 			buildIdentifier: 'TEST',
+			stage: 'PROD',
+			ec2AppDomainName: 'cdk-playground.gutools.co.uk',
+			lambdaDomainName: 'cdk-playground-lambda.gutools.co.uk',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/cdk-playground.test.ts
+++ b/cdk/lib/cdk-playground.test.ts
@@ -13,4 +13,14 @@ describe('The Deploy stack', () => {
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});
+	it('matches the snapshot for CODE', () => {
+		const app = new App({ outdir: '/tmp/cdk.out' });
+		const stack = new CdkPlayground(app, 'CdkPlayground-CODE', {
+			buildIdentifier: 'TEST',
+			stage: 'CODE',
+			ec2AppDomainName: 'cdk-playground.code.dev-gutools.co.uk',
+			lambdaDomainName: 'cdk-playground-lambda.code.dev-gutools.co.uk',
+		});
+		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+	});
 });

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -11,7 +11,7 @@ import { CfnScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
-interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
+interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack'> {
 	/**
 	 * Which application build to run.
 	 * This will typically match the build number provided by CI.
@@ -20,6 +20,20 @@ interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	 * process.env.GITHUB_RUN_NUMBER
 	 */
 	buildIdentifier: string;
+
+	/**
+	 * The domain name for the Play app, running on EC2.
+	 */
+	ec2AppDomainName:
+		| 'cdk-playground.code.dev-gutools.co.uk'
+		| 'cdk-playground.gutools.co.uk';
+
+	/**
+	 * The domain name for the API Gateway lambda.
+	 */
+	lambdaDomainName:
+		| 'cdk-playground-lambda.code.dev-gutools.co.uk'
+		| 'cdk-playground-lambda.gutools.co.uk';
 }
 
 export class CdkPlayground extends GuStack {
@@ -27,15 +41,13 @@ export class CdkPlayground extends GuStack {
 		super(scope, id, {
 			...props,
 			stack: 'deploy',
-			stage: 'PROD',
 			env: { region: 'eu-west-1' },
 		});
 
-		const { buildIdentifier } = props;
+		const { buildIdentifier, ec2AppDomainName, lambdaDomainName } = props;
 		const { stack, stage } = this;
 
 		const ec2App = 'cdk-playground';
-		const ec2AppDomainName = 'cdk-playground.gutools.co.uk';
 
 		const { loadBalancer, autoScalingGroup } = new GuEc2AppExperimental(this, {
 			buildIdentifier,
@@ -106,7 +118,6 @@ export class CdkPlayground extends GuStack {
 		});
 
 		const lambdaApp = 'cdk-playground-lambda';
-		const lambdaDomainName = 'cdk-playground-lambda.gutools.co.uk';
 
 		const lambda = new GuApiLambda(this, 'lambda', {
 			fileName: `cdk-playground-lambda.zip`,

--- a/cdk/lib/event-forwarder.test.ts
+++ b/cdk/lib/event-forwarder.test.ts
@@ -5,7 +5,7 @@ import { EventForwarder } from './event-forwarder';
 describe('The EventForwarder stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
-		const stack = new EventForwarder(app);
+		const stack = new EventForwarder(app, 'EventForwarder', { stage: 'PROD' });
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/event-forwarder.test.ts
+++ b/cdk/lib/event-forwarder.test.ts
@@ -9,4 +9,12 @@ describe('The EventForwarder stack', () => {
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();
 	});
+	it('matches the snapshot for CODE', () => {
+		const app = new App({ outdir: '/tmp/cdk.out' });
+		const stack = new EventForwarder(app, 'EventForwarder-CODE', {
+			stage: 'CODE',
+		});
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
 });

--- a/cdk/lib/event-forwarder.ts
+++ b/cdk/lib/event-forwarder.ts
@@ -1,4 +1,4 @@
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuStack, type GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { Arn } from 'aws-cdk-lib';
@@ -7,13 +7,15 @@ import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 
+type EventForwarderProps = Omit<GuStackProps, 'stack'>;
+
 export class EventForwarder extends GuStack {
-	constructor(scope: App) {
+	constructor(scope: App, id: string, props: EventForwarderProps) {
 		const app = 'event-forwarder';
 
-		super(scope, 'EventForwarder', {
+		super(scope, id, {
+			...props,
 			stack: 'deploy',
-			stage: 'PROD',
 			app,
 			env: {
 				region: 'eu-west-1',


### PR DESCRIPTION
## What does this change?
Create a CODE stage as a pre-cursor to deleting the PROD stage.

This application is a testing ground used by DevX to confirm behaviour of [GuCDK](https://github.com/guardian/cdk) code changes on real infrastructure. Consequently, this application doesn't follow the usual conventions, for example only deploying `main` to PROD.

## How to test
Deploying is the best test here. I've successfully [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/a111c345-da49-419e-8d75-90d9b797723a). Consequently https://cdk-playground.code.dev-gutools.co.uk/tags exists.