### PR TITLE
docs: Update Riff-Raff URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ There are a couple of helpful scripts in the [script](./script) directory:
 6. `./script/scale-in` to simulate a scale in event, decreasing the capacity of the autoscaling group
 
 ## Deploying
-The app is set up in the usual way, with CI on each branch (via GitHub Actions) and [CD](https://riffraff.gutools.co.uk/deployment/history?projectName=devx%3A%3Acdk-playground&stage=PROD&pageSize=20&page=1) on `main`.
+The app is set up in the usual way, with CI on each branch (via GitHub Actions) and [CD](https://riffraff.gutools.co.uk/deployment/history?projectName=devx%3A%3Acdk-playground&stage=CODE&pageSize=20&page=1) on `main`.


### PR DESCRIPTION
## What does this change?
We no longer have a PROD stage, only CODE. See also #771.