### PR TITLE
fix(event-forwarder): Update event filter

### DIFF
--- a/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
+++ b/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
@@ -42,7 +42,7 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
           "detail": {
             "AutoScalingGroupName": [
               {
-                "wildcard": "playground-PROD-cdk-playground-*",
+                "wildcard": "deploy-CODE-cdk-playground-*",
               },
             ],
           },
@@ -98,7 +98,7 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":stack/playground-PROD-cdk-playground*",
+                      ":stack/deploy-CODE-cdk-playground*",
                     ],
                   ],
                 },

--- a/cdk/lib/event-forwarder.ts
+++ b/cdk/lib/event-forwarder.ts
@@ -63,7 +63,7 @@ export class EventForwarder extends GuStack {
 								region,
 								account,
 								resource: 'stack',
-								resourceName: 'playground-PROD-cdk-playground*',
+								resourceName: 'deploy-CODE-cdk-playground*',
 							}),
 						},
 					],
@@ -78,7 +78,7 @@ export class EventForwarder extends GuStack {
 				detail: {
 					AutoScalingGroupName: [
 						{
-							wildcard: 'playground-PROD-cdk-playground-*',
+							wildcard: 'deploy-CODE-cdk-playground-*',
 						},
 					],
 				},

--- a/script/scale-in
+++ b/script/scale-in
@@ -2,12 +2,12 @@
 
 set -e
 
-CLOUDFORMATION_STACK_NAME=deploy-PROD-cdk-playground
+CLOUDFORMATION_STACK_NAME=deploy-CODE-cdk-playground
 
 POLICY_ARN=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile deploy \
+      --profile deployTools \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleInArn") ] | any) | .OutputValue'
@@ -16,7 +16,7 @@ POLICY_ARN=$(
 ASG_NAME=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile deploy \
+      --profile deployTools \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
@@ -25,20 +25,20 @@ ASG_NAME=$(
 CURRENT_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile deploy \
+    --profile deployTools \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )
 
 aws autoscaling execute-policy \
   --policy-name "$POLICY_ARN" \
-  --profile deploy \
+  --profile deployTools \
   --region eu-west-1
 
 NEW_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile deploy \
+    --profile deployTools \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )

--- a/script/scale-out
+++ b/script/scale-out
@@ -2,12 +2,12 @@
 
 set -e
 
-CLOUDFORMATION_STACK_NAME=deploy-PROD-cdk-playground
+CLOUDFORMATION_STACK_NAME=deploy-CODE-cdk-playground
 
 POLICY_ARN=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile deploy \
+      --profile deployTools \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("ScaleOutArn") ] | any) | .OutputValue'
@@ -16,7 +16,7 @@ POLICY_ARN=$(
 ASG_NAME=$(
   aws cloudformation describe-stacks \
       --stack-name "$CLOUDFORMATION_STACK_NAME" \
-      --profile deploy \
+      --profile deployTools \
       --region eu-west-1 \
       --no-cli-pager | \
       jq -r '.Stacks[].Outputs[] | select( [.OutputKey | contains("AutoscalingGroupName") ] | any) | .OutputValue'
@@ -25,20 +25,20 @@ ASG_NAME=$(
 CURRENT_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile deploy \
+    --profile deployTools \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )
 
 aws autoscaling execute-policy \
   --policy-name "$POLICY_ARN" \
-  --profile deploy \
+  --profile deployTools \
   --region eu-west-1
 
 NEW_DESIRED_CAPACITY=$(
   aws autoscaling describe-auto-scaling-groups \
     --auto-scaling-group-names "$ASG_NAME" \
-    --profile deploy \
+    --profile deployTools \
     --region eu-west-1 | \
     jq -r '.AutoScalingGroups[].DesiredCapacity'
 )


### PR DESCRIPTION
## What does this change?
Updates the event filter to use the CODE stack in the deployTools account following the changes in:
- https://github.com/guardian/cdk-playground/pull/769
- https://github.com/guardian/cdk-playground/pull/770
- https://github.com/guardian/cdk-playground/pull/771

## How to test
The last two panels on [this dashboard](https://metrics.gutools.co.uk/d/adyqx5hf3w1s0e/cdk-playground-deployment-dashboard?orgId=1&from=now-6h&to=now&timezone=browser) should populate.