### PR TITLE
Push Docker image to AWS ECR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,3 +48,51 @@ jobs:
               - lambda/cdk-playground-lambda.zip
             event-forwarder:
               - cdk/dist/event-forwarder.zip
+  container:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write # To exchange an OIDC JWT ID token for AWS credentials
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+          mask-aws-account-id: 'true'
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.1
+        with:
+          mask-password: 'true'
+
+      # Image tags are immutable, so we are not adding the branch name or build number as tags as the second invocation would fail.
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }} # TODO Update https://github.com/guardian/riffraff-platform to add the ECR repository URI as a repository secret. This would allow us to login exactly before push, and no earlier.
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          ORIGINAL_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+          PLATFORM: linux/amd64
+        run: |
+          # Remove "refs/heads/" prefix from ORIGINAL_BRANCH_NAME
+          TRIMMED_BRANCH_NAME="${ORIGINAL_BRANCH_NAME#refs/heads/}"
+
+          # Replace / with -
+          BRANCH_NAME=${TRIMMED_BRANCH_NAME//\//-}
+
+          docker build --platform $PLATFORM \
+            -t $REGISTRY/$REPOSITORY:sha-$COMMIT_SHA \
+            -t $REGISTRY/$REPOSITORY:build-$BUILD_NUMBER \
+            -t $REGISTRY/$REPOSITORY:branch-$BRANCH_NAME .
+
+          docker push $REGISTRY/$REPOSITORY --all-tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM sbtscala/scala-sbt:amazoncorretto-al2023-21.0.8_1.12.8_2.13.18 AS build-env
+
+WORKDIR /src
+
+COPY build.sbt ./
+COPY conf ./conf
+COPY app ./app
+COPY project ./project
+
+RUN sbt assembly
+
+
+FROM gcr.io/distroless/java21-debian13
+
+COPY --from=build-env /src/target/scala-2.13/cdk-playground-assembly-1.0-SNAPSHOT.jar /
+EXPOSE 9000
+CMD ["cdk-playground-assembly-1.0-SNAPSHOT.jar"]

--- a/build.sbt
+++ b/build.sbt
@@ -27,15 +27,17 @@ lazy val root = (project in file("."))
       "-unchecked",
       "-Xfatal-warnings"
     ),
-    Universal / javaOptions ++= Seq(
-      s"-Dpidfile.path=/dev/null",
-      s"-J-Dlogs.home=/var/log/${packageName.value}",
-      s"-J-Xlog:gc*:file=/var/log/${packageName.value}/gc.log:time,uptime,level,tags",
-    ),
 
-    libraryDependencies ++= jacksonOverrides
-      ++ akkaSerializationJacksonOverrides
-      ++ Seq(
+    assemblyMergeStrategy := {
+      case PathList("META-INF", "services", _*) => MergeStrategy.first
+      case PathList("META-INF", xs @ _*)        => MergeStrategy.discard
+      case "reference.conf"                     => MergeStrategy.concat
+      case _                                    => MergeStrategy.first
+    },
+
+    libraryDependencies ++= jacksonOverrides ++
+      akkaSerializationJacksonOverrides ++
+      Seq(
         "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
         // Transient dependency of Play. No newer version of Play 2.9 or Play 3.0 with this vulnerability fixed.
         "ch.qos.logback" % "logback-classic" % "1.5.32",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,2 +1,3 @@
 play.application.loader= AppLoader
 play.http.secret.key = "this is not a production system, so it doesn't matter too much that this is plain text"
+play.server.http.port = 9000

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -3,19 +3,8 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>${application.home:-.}/logs/application.log</file>
-    <encoder>
-      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-    </encoder>
-  </appender>
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-  </appender>
-
-  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="FILE" />
   </appender>
 
   <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
@@ -23,7 +12,6 @@
   </appender>
 
   <root level="INFO">
-    <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,5 @@ addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.14" artifacts Artifact("jdeb", "jar", "jar")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")


### PR DESCRIPTION
## What does this change?
This is part of a DevX RelOps spike to explore containerised workflows. In this change, the CI for this repository is updated to additionally push an image to AWS ECR, the repository of which was created in https://github.com/guardian/riffraff-platform/pull/710.

I've opted against using https://www.scala-sbt.org/sbt-native-packager/formats/docker.html and instead have added an explicit `Dockerfile` as:
- It is slightly easier to debug
- It should allow us to explore [using AWS CDK to build the container](https://docs.aws.amazon.com/cdk/v2/guide/build-containers.html)

In order to produce the smallest image possible, we're using a [distroless](https://github.com/googlecontainertools/distroless) Java21 image.

## How has this change been tested?
We can pull and run the pushed image on our local machine:

```bash
AWS_PROFILE=deployTools
AWS_DEFAULT_REGION=eu-west-1
ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account)
REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
COMMIT_SHA=$(gh pr view 1032 --repo guardian/cdk-playground --json headRefOid | jq -r ".headRefOid")
IMAGE="${REGISTRY}/guardian/cdk-playground:${COMMIT_SHA}"

# Login to AWS ECR https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html
aws ecr get-login-password | docker login --username AWS --password-stdin $REGISTRY

# Pull image
docker pull $IMAGE

# Run image
docker run --platform linux/amd64 --publish 9000:9000 $IMAGE
```

With the image running, we can then visit `localhost:9000`:

```console
❯ curl --silent localhost:9000 | jq .
{
  "name": "cdk-playground",
  "buildTime": 1774960302488,
  "branch": "unknown-branch",
  "gitCommitId": null,
  "scalaVersion": "2.13.18",
  "version": "1.0-SNAPSHOT",
  "sbtVersion": "1.12.6",
  "buildNumber": null
}
```

> [!NOTE]
> Parts of the manifest are missing/incorrect, such as `branch`, `gitCommitId` and `buildNumber`. I think we can look at these separately.