### PR TITLE
ci: Correctly obtain commit sha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,19 @@ jobs:
       pull-requests: write #...to comment on PRs
 
     steps:
+      - name: Build facts
+        env:
+          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }} # When invoked from `pull_request`, `github.sha` is not the latest commit of the feature branch. All other times, it is.
+        run: |
+          # Remove "refs/heads/" prefix from RAW_BRANCH_NAME
+          BRANCH_NAME="${RAW_BRANCH_NAME#refs/heads/}"
+
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
+          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_ENV
+          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_ENV
+
       # Checkout the branch
       - uses: actions/checkout@v6.0.2
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,18 +44,10 @@ lazy val root = (project in file("."))
       scalaVersion,
       sbtVersion,
 
-      // copied from https://github.com/guardian/sbt-riffraff-artifact/blob/e6f5e62d8f776b1004f72ed1ea415328fa43ed31/src/main/scala/com/gu/riffraff/artifact/BuildInfo.scala
-      BuildInfoKey.sbtbuildinfoConstantEntry("buildNumber", env("GITHUB_RUN_NUMBER")),
+      BuildInfoKey.sbtbuildinfoConstantEntry("buildNumber", env("BUILD_NUMBER")),
       BuildInfoKey.sbtbuildinfoConstantEntry("buildTime", System.currentTimeMillis),
-      BuildInfoKey.sbtbuildinfoConstantEntry("gitCommitId", env("GITHUB_SHA")),
-
-      BuildInfoKey.sbtbuildinfoConstantEntry(
-        "branch",
-        env("GITHUB_HEAD_REF")
-          .orElse(env("GITHUB_REF"))
-          .orElse(Some("unknown-branch"))
-          .get
-          .stripPrefix("refs/heads/")),
+      BuildInfoKey.sbtbuildinfoConstantEntry("gitCommitId", env("COMMIT_SHA")),
+      BuildInfoKey.sbtbuildinfoConstantEntry("branch", env("BRANCH_NAME")),
     ),
     buildInfoOptions := Seq(
       BuildInfoOption.Traits("management.BuildInfo"),


### PR DESCRIPTION
## What does this change?
From https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request, the `GITHUB_SHA` of a `pull_request` event represents the:

> Last merge commit on the `GITHUB_REF` branch

Confusingly, this is not the sha of the latest commit on the feature branch. See also https://github.com/orgs/community/discussions/26325 for some additional commentary.

This change correctly obtains the commit sha for a `pull_request` event.

Additionally, it pushes the build fact gathering to a workflow step, removing logic from `build.sbt`.

## How has this change been tested?
To demonstrate the issue, let's find the latest commit of `main`:

```console
❯ gh api repos/guardian/cdk-playground/commits/main | jq -r .sha
0e032af7b4bf0d8bb41620faafd6a4d4ebef1175
```

When [deployed](https://riffraff.gutools.co.uk/deployment/view/0c321560-4203-4687-9416-bf3036fa5359), if we `curl` the service, we get:

```console
❯ curl --silent https://cdk-playground.code.dev-gutools.co.uk/ | jq .
{
  "name": "cdk-playground",
  "buildTime": 1776863411006,
  "branch": "main",
  "gitCommitId": "a0a41f1c6176c05f59339d8f26995eb6cee13311", # ❌ This is not correct, it does not match the latest commit on main!
  "scalaVersion": "2.13.18",
  "version": "1.0-SNAPSHOT",
  "sbtVersion": "1.12.9",
  "buildNumber": "2221"
}
```

Next, let's get the latest commit on this branch:

```console
❯ gh api repos/guardian/cdk-playground/commits/aa/build-facts | jq -r .sha
6a6ae8102313f97b1616cc7ceb5b76a58856c188
```

When [deployed](https://riffraff.gutools.co.uk/deployment/view/8ec6b9be-a976-4335-af1a-d52ef9f0b014), if we `curl` the service, we get:

```console
❯ curl --silent https://cdk-playground.code.dev-gutools.co.uk/ | jq .
{
  "name": "cdk-playground",
  "buildTime": 1776880726918,
  "branch": "aa/build-facts",
  "gitCommitId": "6a6ae8102313f97b1616cc7ceb5b76a58856c188", # ✅  This is correct, it matches the latest commit on this branch!
  "scalaVersion": "2.13.18",
  "version": "1.0-SNAPSHOT",
  "sbtVersion": "1.12.9",
  "buildNumber": "2227"
}
```

Since https://github.com/guardian/cdk-playground/pull/1045 each build publishes an image to AWS ECR. If we run the image from `main` locally, we get:

```console
AWS_PROFILE=deployTools
AWS_DEFAULT_REGION=eu-west-1
ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account)
REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
IMAGE="${REGISTRY}/guardian/cdk-playground:branch-main"

# Login to AWS ECR https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html
aws ecr get-login-password | docker login --username AWS --password-stdin $REGISTRY

# Pull image
docker pull $IMAGE

# Run image
docker run --platform linux/amd64 --publish 9000:9000 $IMAGE

curl --silent localhost:9000 | jq .
{
  "name": "cdk-playground",
  "buildTime": 1776863436518,
  "branch": "main",
  "gitCommitId": "a0a41f1c6176c05f59339d8f26995eb6cee13311", # ❌ This is not correct, it does not match the latest commit on main!
  "scalaVersion": "2.13.18",
  "version": "1.0-SNAPSHOT",
  "sbtVersion": "1.12.9",
  "buildNumber": "2221"
}
```

If we run the image from this branch, we get:

```console
AWS_PROFILE=deployTools
AWS_DEFAULT_REGION=eu-west-1
ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account)
REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
IMAGE="${REGISTRY}/guardian/cdk-playground:branch-aa-build-facts"

# Login to AWS ECR https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html
aws ecr get-login-password | docker login --username AWS --password-stdin $REGISTRY

# Pull image
docker pull $IMAGE

# Run image
docker run --platform linux/amd64 --publish 9000:9000 $IMAGE

curl --silent localhost:9000 | jq .
{
  "name": "cdk-playground",
  "buildTime": 1776880755430,
  "branch": "aa-build-facts",
  "gitCommitId": "6a6ae8102313f97b1616cc7ceb5b76a58856c188",  # ✅  This is correct, it matches the latest commit on this branch!
  "scalaVersion": "2.13.18",
  "version": "1.0-SNAPSHOT",
  "sbtVersion": "1.12.9",
  "buildNumber": "2227"
}
```

> [!NOTE]
> The commit sha shown in Riff-Raff is also incorrect due to [similar logic in `guardian/actions-riff-raff`](https://github.com/guardian/actions-riff-raff/blob/31ff9454bb6822b12fefe6388fccdf7a60c772aa/src/config.ts#L218).
> 
> <img width="774" height="253" alt="image" src="https://github.com/user-attachments/assets/1ea6c2be-ed81-405d-bf82-58f5defe92fe" />