### PR TITLE
Attempt to share a load balancer with GuEc2App pattern

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -48,7 +48,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     "FargateServiceWithClusterLoadBalancerDNS13D5ADEE": {
       "Value": {
         "Fn::GetAtt": [
-          "FargateServiceWithClusterLBC0F3A1A2",
+          "LoadBalancerCdkplayground7C6B4D97",
           "DNSName",
         ],
       },
@@ -61,7 +61,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "https://",
             {
               "Fn::GetAtt": [
-                "FargateServiceWithClusterLBC0F3A1A2",
+                "LoadBalancerCdkplayground7C6B4D97",
                 "DNSName",
               ],
             },
@@ -505,7 +505,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
-              "FargateServiceWithClusterLBC0F3A1A2",
+              "LoadBalancerCdkplayground7C6B4D97",
               "DNSName",
             ],
           },
@@ -515,175 +515,11 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
-    "FargateServiceWithClusterLBC0F3A1A2": {
-      "Properties": {
-        "LoadBalancerAttributes": [
-          {
-            "Key": "deletion_protection.enabled",
-            "Value": "false",
-          },
-        ],
-        "Scheme": "internet-facing",
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "FargateServiceWithClusterLBSecurityGroupC2837562",
-              "GroupId",
-            ],
-          },
-        ],
-        "Subnets": {
-          "Ref": "VpcPublicParam",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Type": "application",
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    },
-    "FargateServiceWithClusterLBPublicListenerC7225768": {
-      "Properties": {
-        "Certificates": [
-          {
-            "CertificateArn": {
-              "Ref": "CertificateCdkplaygroundecsD6C69B43",
-            },
-          },
-        ],
-        "DefaultActions": [
-          {
-            "TargetGroupArn": {
-              "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
-            },
-            "Type": "forward",
-          },
-        ],
-        "LoadBalancerArn": {
-          "Ref": "FargateServiceWithClusterLBC0F3A1A2",
-        },
-        "Port": 443,
-        "Protocol": "HTTPS",
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
-    },
-    "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8": {
-      "Properties": {
-        "HealthCheckIntervalSeconds": 10,
-        "HealthCheckPath": "/healthcheck",
-        "HealthCheckTimeoutSeconds": 5,
-        "HealthyThresholdCount": 5,
-        "Port": 80,
-        "Protocol": "HTTP",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "TargetGroupAttributes": [
-          {
-            "Key": "stickiness.enabled",
-            "Value": "false",
-          },
-        ],
-        "TargetType": "ip",
-        "UnhealthyThresholdCount": 2,
-        "VpcId": {
-          "Ref": "VpcIdParam",
-        },
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-    },
-    "FargateServiceWithClusterLBSecurityGroupC2837562": {
-      "Properties": {
-        "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundCODEFargateServiceWithClusterLB0054D6CB",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 443",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcIdParam",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "FargateServiceWithClusterLBSecurityGrouptoCdkPlaygroundCODEFargateServiceWithClusterServiceSecurityGroup9E89F2FB9000E419D184": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "FargateServiceWithClusterServiceSecurityGroupC199044E",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "FargateServiceWithClusterLBSecurityGroupC2837562",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
     "FargateServiceWithClusterServiceEC3A63FF": {
       "DependsOn": [
-        "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
-        "FargateServiceWithClusterLBPublicListenerC7225768",
         "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
+        "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A",
+        "LoadBalancerCdkplaygroundPublicListener86C37BA4",
       ],
       "Properties": {
         "Cluster": {
@@ -706,7 +542,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "ContainerName": "cdk-playground",
             "ContainerPort": 9000,
             "TargetGroupArn": {
-              "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
+              "Ref": "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A",
             },
           },
         ],
@@ -787,7 +623,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "FargateServiceWithClusterServiceSecurityGroupfromCdkPlaygroundCODEFargateServiceWithClusterLBSecurityGroup8854CFAF900044BA2FDA": {
+    "FargateServiceWithClusterServiceSecurityGroupfromCdkPlaygroundCODELoadBalancerCdkplaygroundSecurityGroup0DBDF61090004BCEB5F1": {
       "DependsOn": [
         "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
       ],
@@ -803,7 +639,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": {
           "Fn::GetAtt": [
-            "FargateServiceWithClusterLBSecurityGroupC2837562",
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
             "GroupId",
           ],
         },
@@ -1325,6 +1161,75 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
     },
+    "LoadBalancerCdkplaygroundPublicListener86C37BA4": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateCdkplaygroundecsD6C69B43",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerCdkplayground7C6B4D97",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 80,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
     "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05": {
       "Properties": {
         "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundCODELoadBalancerCdkplaygroundACDA30E1",
@@ -1364,6 +1269,27 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEFargateServiceWithClusterServiceSecurityGroup9E89F2FB9000314DCF0B": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceWithClusterServiceSecurityGroupC199044E",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEGuHttpsEgressSecurityGroupCdkplayground610B4DD790000DEACC63": {
       "Properties": {

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -31,7 +31,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuParameter",
       "GuCertificate",
       "GuParameterStoreReadPolicy",
-      "GuCname",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -498,28 +497,10 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::ECS::Cluster",
     },
-    "EcsDns": {
-      "Properties": {
-        "Name": "cdk-playground-ecs.code.dev-gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": [
-          {
-            "Fn::GetAtt": [
-              "LoadBalancerCdkplayground7C6B4D97",
-              "DNSName",
-            ],
-          },
-        ],
-        "Stage": "CODE",
-        "TTL": 60,
-      },
-      "Type": "Guardian::DNS::RecordSet",
-    },
     "FargateServiceWithClusterServiceEC3A63FF": {
       "DependsOn": [
         "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
         "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A",
-        "LoadBalancerCdkplaygroundPublicListener86C37BA4",
       ],
       "Properties": {
         "Cluster": {
@@ -1078,8 +1059,21 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         ],
         "DefaultActions": [
           {
-            "TargetGroupArn": {
-              "Ref": "TargetGroupCdkplayground7A453FC2",
+            "ForwardConfig": {
+              "TargetGroups": [
+                {
+                  "TargetGroupArn": {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "Weight": 50,
+                },
+                {
+                  "TargetGroupArn": {
+                    "Ref": "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A",
+                  },
+                  "Weight": 50,
+                },
+              ],
             },
             "Type": "forward",
           },
@@ -1160,31 +1154,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "Type": "application",
       },
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    },
-    "LoadBalancerCdkplaygroundPublicListener86C37BA4": {
-      "Properties": {
-        "Certificates": [
-          {
-            "CertificateArn": {
-              "Ref": "CertificateCdkplaygroundecsD6C69B43",
-            },
-          },
-        ],
-        "DefaultActions": [
-          {
-            "TargetGroupArn": {
-              "Ref": "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A",
-            },
-            "Type": "forward",
-          },
-        ],
-        "LoadBalancerArn": {
-          "Ref": "LoadBalancerCdkplayground7C6B4D97",
-        },
-        "Port": 443,
-        "Protocol": "HTTPS",
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
     "LoadBalancerCdkplaygroundPublicListenerECSGroupB6C93B7A": {
       "Properties": {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -164,9 +164,8 @@ export class CdkPlayground extends GuStack {
 			domainName: ecsDomainName,
 		});
 
-		// ## Potential Issues
-		// * Load balancer deletion protection is false (to match pattern this should be true)
-		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
+		// ## TODO
+		// * This currently allows all outbound traffic by default (to match pattern this would be HTTPs only)
 		// * Logging - ships to CloudWatch by default and https://github.com/guardian/cloudwatch-logs-management can be
 		//   configured to pick up from there
 		// * Deployment?
@@ -179,8 +178,6 @@ export class CdkPlayground extends GuStack {
 		// AWS::IAM::Role ('execution role' - used for pulling image etc. - can pass in your own)
 		// AWS::IAM::Role ('task role' - used for application's runtime permissions e.g. reading config from SSM - can pass in your own)
 		// AWS::IAM::Policy
-		// AWS::ElasticLoadBalancingV2::LoadBalancer (present in GuEc2App; no need to duplicate)
-		// AWS::ElasticLoadBalancingV2::Listener (present in GuEc2App; no need to duplicate)
 		// AWS::ElasticLoadBalancingV2::TargetGroup (present in GuEc2App; need new dedicated group)
 		// AWS::EC2::SecurityGroups and AWS::EC2::SecurityGroupEgress / AWS::EC2::SecurityGroupIngress (from memory, aws-cdk auto-generates these anyway)
 

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -185,6 +185,8 @@ export class CdkPlayground extends GuStack {
 				vpc,
 				protocol: ApplicationProtocol.HTTPS,
 				certificate,
+				// Can pass this in from the EC2 app but we end up with 2 listeners for port 443; presumably this won't work
+				loadBalancer,
 				// healthCheckGracePeriod - should we define this? AWS CDK is defaulting to 1 minute
 				// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
 				taskImageOptions: {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -19,6 +19,7 @@ import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
 import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
 import { ApplicationProtocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { CfnListener } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
@@ -49,7 +50,12 @@ export class CdkPlayground extends GuStack {
 
 		const ec2App = 'cdk-playground';
 
-		const { loadBalancer, autoScalingGroup } = new GuEc2AppExperimental(this, {
+		const {
+			loadBalancer,
+			autoScalingGroup,
+			listener,
+			targetGroup: ec2TargetGroup,
+		} = new GuEc2AppExperimental(this, {
 			buildIdentifier,
 			applicationPort: 9000,
 			app: ec2App,
@@ -185,7 +191,6 @@ export class CdkPlayground extends GuStack {
 				vpc,
 				protocol: ApplicationProtocol.HTTPS,
 				certificate,
-				// Can pass this in from the EC2 app but we end up with 2 listeners for port 443; presumably this won't work
 				loadBalancer,
 				// healthCheckGracePeriod - should we define this? AWS CDK is defaulting to 1 minute
 				// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
@@ -196,6 +201,32 @@ export class CdkPlayground extends GuStack {
 				},
 			},
 		);
+
+		// ApplicationLoadBalancedFargateService creates its own listener.
+		// We need to get rid of this as an ALB can only have one listener per port.
+		const publicListener = loadBalancer.node.findChild('PublicListener');
+		// This extra bit is needed as removing the listener node itself also removes the ECS target group
+		publicListener.node.tryRemoveChild('Resource');
+
+		// In the future we could do this within the pattern code, so we wouldn't need escape hatches
+		const cfnListener = listener.node.defaultChild as CfnListener;
+		cfnListener.defaultActions = [
+			{
+				type: 'forward',
+				forwardConfig: {
+					targetGroups: [
+						{
+							targetGroupArn: ec2TargetGroup.targetGroupArn,
+							weight: 50,
+						},
+						{
+							targetGroupArn: loadBalancedEcs.targetGroup.targetGroupArn,
+							weight: 50,
+						},
+					],
+				},
+			},
+		];
 
 		// EC2 pattern helps with this wiring and provides useful default permissions, although most of these are irrelevant when running in ECS
 		new GuParameterStoreReadPolicy(this, { app: ecsApp }).attachToRole(
@@ -208,14 +239,6 @@ export class CdkPlayground extends GuStack {
 			timeout: Duration.seconds(5),
 			healthyThresholdCount: 5,
 			unhealthyThresholdCount: 2,
-		});
-
-		// Let's create a separate GuCname for now, but we could use the existing one to perform a migration if desired
-		new GuCname(this, 'EcsDns', {
-			app: ecsApp,
-			ttl: Duration.minutes(1),
-			domainName: ecsDomainName,
-			resourceRecord: loadBalancedEcs.loadBalancer.loadBalancerDnsName,
 		});
 
 		const lambdaApp = 'cdk-playground-lambda';


### PR DESCRIPTION
This PR builds upon https://github.com/guardian/cdk-playground/pull/1035. It demonstrates how we could modify the AWS ECS pattern to make it compatible with our existing ALB (and listener).

Initially (in https://github.com/guardian/cdk-playground/pull/1042/commits/987ed3db98efc802067da241295ffe7f2c070310) I tried to pass the existing load balancer into the pattern, but this still creates an additional HTTPs listener (`AWS::ElasticLoadBalancingV2::Listener`), resulting in the following error on deployment:
> A listener already exists on this port for this load balancer

As far as I can tell the duplicate listener can only be removed using escape hatches (https://github.com/guardian/cdk-playground/pull/1042/changes/cb29ba331de1057122b554c47030e08f8c21d947). Although this works as expected[^1], I think it would be undesirable to have code like this in the GuCDK library and I also suspect it would be very brittle (e.g. it might break when AWS make updates to this pattern, or if/when users try to interact with the listener that we're hackily removing!).

[^1]: I've confirmed that requests to https://cdk-playground.code.dev-gutools.co.uk are served via EC2 _and_ ECS when this branch is deployed (target group weighting is 50/50 so there is an equal chance of hitting either backend when making a request).