### PR TITLE
Experiment with using ECS constructs rather than patterns

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -563,7 +563,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
                   {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/guardian/cdk-playground:bd1737b461371a7e956eae24f12188946946c55f",
+                  "/guardian/cdk-playground:build-TEST",
                 ],
               ],
             },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -25,10 +25,12 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuRiffRaffDeploymentIdParameter",
+      "GuCname",
       "GuParameter",
       "GuParameter",
       "GuParameter",
       "GuParameter",
+      "GuCertificate",
       "GuCname",
       "GuApiLambda",
       "GuCertificate",
@@ -55,7 +57,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "Fn::Join": [
           "",
           [
-            "http://",
+            "https://",
             {
               "Fn::GetAtt": [
                 "FargateServiceWithClusterLBC0F3A1A2",
@@ -363,6 +365,41 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
     },
+    "CertificateCdkplaygroundecsD6C69B43": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "cdk-playground-ecs.code.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Name",
+            "Value": "CdkPlayground-CODE/CertificateCdkplaygroundecs",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
     "CertificateCdkplaygroundlambda82D0BE4D": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -464,6 +501,23 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::ECS::Cluster",
     },
+    "EcsDns": {
+      "Properties": {
+        "Name": "cdk-playground-ecs.code.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "FargateServiceWithClusterLBC0F3A1A2",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "CODE",
+        "TTL": 60,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
     "FargateServiceWithClusterLBC0F3A1A2": {
       "Properties": {
         "LoadBalancerAttributes": [
@@ -508,6 +562,13 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     },
     "FargateServiceWithClusterLBPublicListenerC7225768": {
       "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateCdkplaygroundecsD6C69B43",
+            },
+          },
+        ],
         "DefaultActions": [
           {
             "TargetGroupArn": {
@@ -519,8 +580,8 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "LoadBalancerArn": {
           "Ref": "FargateServiceWithClusterLBC0F3A1A2",
         },
-        "Port": 80,
-        "Protocol": "HTTP",
+        "Port": 443,
+        "Protocol": "HTTPS",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
@@ -565,10 +626,10 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "SecurityGroupIngress": [
           {
             "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 80",
-            "FromPort": 80,
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
             "IpProtocol": "tcp",
-            "ToPort": 80,
+            "ToPort": 443,
           },
         ],
         "Tags": [

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -35,6 +35,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
+      "GuAsgMinInstancesInServiceParameterExperimental",
     ],
     "gu:cdk:version": "TEST",
   },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -27,8 +27,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuRiffRaffDeploymentIdParameter",
       "GuCname",
       "GuParameter",
-      "GuParameter",
-      "GuParameter",
       "GuParameterStoreReadPolicy",
       "GuApplicationTargetGroup",
       "GuHttpsEgressSecurityGroup",
@@ -125,17 +123,8 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
-    "VpcIdParam": {
-      "Default": "/account/vpc/primary/id",
-      "Description": "The VPC to deploy the structuriser to",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "VpcPrivateParam": {
+    "VpcPrivateSubnetsParam": {
       "Default": "/account/vpc/primary/subnets/private",
-      "Type": "AWS::SSM::Parameter::Value<List<String>>",
-    },
-    "VpcPublicParam": {
-      "Default": "/account/vpc/primary/subnets/public",
       "Type": "AWS::SSM::Parameter::Value<List<String>>",
     },
     "cdkplaygroundPrivateSubnets": {
@@ -481,7 +470,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
               },
             ],
             "Subnets": {
-              "Ref": "VpcPrivateParam",
+              "Ref": "VpcPrivateSubnetsParam",
             },
           },
         },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -656,7 +656,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "FargateServiceWithClusterLBSecurityGrouptoCdkPlaygroundCODEFargateServiceWithClusterServiceSecurityGroup9E89F2FB804547ACEE": {
+    "FargateServiceWithClusterLBSecurityGrouptoCdkPlaygroundCODEFargateServiceWithClusterServiceSecurityGroup9E89F2FB9000E419D184": {
       "Properties": {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": {
@@ -665,7 +665,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "GroupId",
           ],
         },
-        "FromPort": 80,
+        "FromPort": 9000,
         "GroupId": {
           "Fn::GetAtt": [
             "FargateServiceWithClusterLBSecurityGroupC2837562",
@@ -673,7 +673,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
           ],
         },
         "IpProtocol": "tcp",
-        "ToPort": 80,
+        "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
@@ -702,7 +702,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "LoadBalancers": [
           {
             "ContainerName": "web",
-            "ContainerPort": 80,
+            "ContainerPort": 9000,
             "TargetGroupArn": {
               "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
             },
@@ -785,13 +785,13 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "FargateServiceWithClusterServiceSecurityGroupfromCdkPlaygroundCODEFargateServiceWithClusterLBSecurityGroup8854CFAF804B1FDF6A": {
+    "FargateServiceWithClusterServiceSecurityGroupfromCdkPlaygroundCODEFargateServiceWithClusterLBSecurityGroup8854CFAF900044BA2FDA": {
       "DependsOn": [
         "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
       ],
       "Properties": {
         "Description": "Load balancer to target",
-        "FromPort": 80,
+        "FromPort": 9000,
         "GroupId": {
           "Fn::GetAtt": [
             "FargateServiceWithClusterServiceSecurityGroupC199044E",
@@ -805,7 +805,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "GroupId",
           ],
         },
-        "ToPort": 80,
+        "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
@@ -842,7 +842,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "Name": "web",
             "PortMappings": [
               {
-                "ContainerPort": 80,
+                "ContainerPort": 9000,
                 "Protocol": "tcp",
               },
             ],

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -25,11 +25,14 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuRiffRaffDeploymentIdParameter",
+      "GuParameter",
+      "GuParameter",
+      "GuParameter",
+      "GuParameter",
       "GuCname",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
-      "GuAsgMinInstancesInServiceParameterExperimental",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -37,6 +40,30 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     "AutoscalingGroupName": {
       "Value": {
         "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
+      },
+    },
+    "FargateServiceWithClusterLoadBalancerDNS13D5ADEE": {
+      "Value": {
+        "Fn::GetAtt": [
+          "FargateServiceWithClusterLBC0F3A1A2",
+          "DNSName",
+        ],
+      },
+    },
+    "FargateServiceWithClusterServiceURLA598AD71": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "http://",
+            {
+              "Fn::GetAtt": [
+                "FargateServiceWithClusterLBC0F3A1A2",
+                "DNSName",
+              ],
+            },
+          ],
+        ],
       },
     },
     "LoadBalancerCdkplaygroundDnsName": {
@@ -114,10 +141,27 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "Description": "Used by Riff-Raff to inject the deployment ID.",
       "Type": "String",
     },
+    "VpcAZParam": {
+      "Default": "/account/vpc/primary/availability-zones",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
+    },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "VpcIdParam": {
+      "Default": "/account/vpc/primary/id",
+      "Description": "The VPC to deploy the structuriser to",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "VpcPrivateParam": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
+    },
+    "VpcPublicParam": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
     },
     "cdkplaygroundPrivateSubnets": {
       "Default": "/account/vpc/primary/subnets/private",
@@ -396,6 +440,545 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "TTL": 3600,
       },
       "Type": "Guardian::DNS::RecordSet",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpc18E0451A": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "FargateServiceWithClusterLBC0F3A1A2": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "false",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "FargateServiceWithClusterLBSecurityGroupC2837562",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "VpcPublicParam",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "FargateServiceWithClusterLBPublicListenerC7225768": {
+      "Properties": {
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "FargateServiceWithClusterLBC0F3A1A2",
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8": {
+      "Properties": {
+        "Port": 80,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "VpcId": {
+          "Ref": "VpcIdParam",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "FargateServiceWithClusterLBSecurityGroupC2837562": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundCODEFargateServiceWithClusterLB0054D6CB",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcIdParam",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "FargateServiceWithClusterLBSecurityGrouptoCdkPlaygroundCODEFargateServiceWithClusterServiceSecurityGroup9E89F2FB804547ACEE": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceWithClusterServiceSecurityGroupC199044E",
+            "GroupId",
+          ],
+        },
+        "FromPort": 80,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceWithClusterLBSecurityGroupC2837562",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 80,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "FargateServiceWithClusterServiceEC3A63FF": {
+      "DependsOn": [
+        "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
+        "FargateServiceWithClusterLBPublicListenerC7225768",
+        "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
+      ],
+      "Properties": {
+        "Cluster": {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc18E0451A",
+        },
+        "DeploymentConfiguration": {
+          "Alarms": {
+            "AlarmNames": [],
+            "Enable": false,
+            "Rollback": false,
+          },
+          "MaximumPercent": 200,
+          "MinimumHealthyPercent": 50,
+        },
+        "EnableECSManagedTags": false,
+        "HealthCheckGracePeriodSeconds": 60,
+        "LaunchType": "FARGATE",
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 80,
+            "TargetGroupArn": {
+              "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
+            },
+          },
+        ],
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": [
+              {
+                "Fn::GetAtt": [
+                  "FargateServiceWithClusterServiceSecurityGroupC199044E",
+                  "GroupId",
+                ],
+              },
+            ],
+            "Subnets": {
+              "Ref": "VpcPrivateParam",
+            },
+          },
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TaskDefinition": {
+          "Ref": "FargateServiceWithClusterTaskDefADD1A9C3",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "FargateServiceWithClusterServiceSecurityGroupC199044E": {
+      "DependsOn": [
+        "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
+      ],
+      "Properties": {
+        "GroupDescription": "CdkPlayground-CODE/FargateServiceWithCluster/Service/SecurityGroup",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcIdParam",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "FargateServiceWithClusterServiceSecurityGroupfromCdkPlaygroundCODEFargateServiceWithClusterLBSecurityGroup8854CFAF804B1FDF6A": {
+      "DependsOn": [
+        "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
+      ],
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 80,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceWithClusterServiceSecurityGroupC199044E",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "FargateServiceWithClusterLBSecurityGroupC2837562",
+            "GroupId",
+          ],
+        },
+        "ToPort": 80,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "FargateServiceWithClusterTaskDefADD1A9C3": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.eu-west-1.",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/guardian/cdk-playground:TEST",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "FargateServiceWithClusterTaskDefwebLogGroup1B64019F",
+                },
+                "awslogs-region": "eu-west-1",
+                "awslogs-stream-prefix": "FargateServiceWithCluster",
+              },
+            },
+            "Name": "web",
+            "PortMappings": [
+              {
+                "ContainerPort": 80,
+                "Protocol": "tcp",
+              },
+            ],
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "FargateServiceWithClusterTaskDefExecutionRole4ED71D3B",
+            "Arn",
+          ],
+        },
+        "Family": "CdkPlaygroundCODEFargateServiceWithClusterTaskDef754180B4",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "FargateServiceWithClusterTaskDefExecutionRole4ED71D3B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "FargateServiceWithClusterTaskDefExecutionRoleDefaultPolicy390D6692": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecr:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":repository/guardian/cdk-playground",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "FargateServiceWithClusterTaskDefwebLogGroup1B64019F",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "FargateServiceWithClusterTaskDefExecutionRoleDefaultPolicy390D6692",
+        "Roles": [
+          {
+            "Ref": "FargateServiceWithClusterTaskDefExecutionRole4ED71D3B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "FargateServiceWithClusterTaskDefTaskRole6DACF8B7": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "FargateServiceWithClusterTaskDefwebLogGroup1B64019F": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "GetDistributablePolicyCdkplaygroundBFB4D02B": {
       "Properties": {

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -587,6 +587,10 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     },
     "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8": {
       "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
         "Port": 80,
         "Protocol": "HTTP",
         "Tags": [
@@ -614,6 +618,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
           },
         ],
         "TargetType": "ip",
+        "UnhealthyThresholdCount": 2,
         "VpcId": {
           "Ref": "VpcIdParam",
         },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -29,7 +29,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuParameter",
       "GuParameter",
       "GuParameter",
-      "GuParameter",
       "GuCertificate",
       "GuCname",
       "GuApiLambda",
@@ -143,10 +142,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     "RiffRaffDeploymentId": {
       "Description": "Used by Riff-Raff to inject the deployment ID.",
       "Type": "String",
-    },
-    "VpcAZParam": {
-      "Default": "/account/vpc/primary/availability-zones",
-      "Type": "AWS::SSM::Parameter::Value<List<String>>",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -589,6 +589,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
+        "HealthCheckPort": "9000",
         "HealthCheckTimeoutSeconds": 5,
         "HealthyThresholdCount": 5,
         "Port": 80,

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -553,7 +553,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "TargetType": "ip",
         "UnhealthyThresholdCount": 2,
         "VpcId": {
-          "Ref": "VpcIdParam",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
@@ -897,7 +897,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
           },
         ],
         "VpcId": {
-          "Ref": "VpcIdParam",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -706,7 +706,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "LaunchType": "FARGATE",
         "LoadBalancers": [
           {
-            "ContainerName": "web",
+            "ContainerName": "cdk-playground",
             "ContainerPort": 9000,
             "TargetGroupArn": {
               "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
@@ -838,13 +838,13 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
               "LogDriver": "awslogs",
               "Options": {
                 "awslogs-group": {
-                  "Ref": "FargateServiceWithClusterTaskDefwebLogGroup1B64019F",
+                  "Ref": "FargateServiceWithClusterTaskDefcdkplaygroundLogGroup4AEF846A",
                 },
                 "awslogs-region": "eu-west-1",
                 "awslogs-stream-prefix": "FargateServiceWithCluster",
               },
             },
-            "Name": "web",
+            "Name": "cdk-playground",
             "PortMappings": [
               {
                 "ContainerPort": 9000,
@@ -969,7 +969,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "FargateServiceWithClusterTaskDefwebLogGroup1B64019F",
+                  "FargateServiceWithClusterTaskDefcdkplaygroundLogGroup4AEF846A",
                   "Arn",
                 ],
               },
@@ -1021,7 +1021,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "FargateServiceWithClusterTaskDefwebLogGroup1B64019F": {
+    "FargateServiceWithClusterTaskDefcdkplaygroundLogGroup4AEF846A": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Tags": [

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -30,6 +30,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuParameter",
       "GuParameter",
       "GuParameterStoreReadPolicy",
+      "GuApplicationTargetGroup",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -463,7 +464,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "ContainerName": "cdk-playground",
             "ContainerPort": 9000,
             "TargetGroupArn": {
-              "Ref": "EcsTargetGroup06D481F9",
+              "Ref": "EcsTargetGroupCdkplaygroundecsF5A8D17A",
             },
           },
         ],
@@ -568,15 +569,20 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "EcsTargetGroup06D481F9": {
+    "EcsTargetGroupCdkplaygroundecsF5A8D17A": {
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
         "HealthCheckTimeoutSeconds": 5,
         "HealthyThresholdCount": 5,
         "Port": 9000,
         "Protocol": "HTTP",
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -595,6 +601,10 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
           },
         ],
         "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
           {
             "Key": "stickiness.enabled",
             "Value": "false",
@@ -1049,7 +1059,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
                 },
                 {
                   "TargetGroupArn": {
-                    "Ref": "EcsTargetGroup06D481F9",
+                    "Ref": "EcsTargetGroupCdkplaygroundecsF5A8D17A",
                   },
                   "Weight": 50,
                 },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -830,7 +830,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
                   {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/guardian/cdk-playground:TEST",
+                  "/guardian/cdk-playground:bd1737b461371a7e956eae24f12188946946c55f",
                 ],
               ],
             },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -30,6 +30,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuParameter",
       "GuParameter",
       "GuCertificate",
+      "GuParameterStoreReadPolicy",
       "GuCname",
       "GuApiLambda",
       "GuCertificate",
@@ -1431,6 +1432,57 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "Roles": [
           {
             "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStoreReadCdkplaygroundecsB1E187C6": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-ecs",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-ecs/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -31,6 +31,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuParameter",
       "GuParameterStoreReadPolicy",
       "GuApplicationTargetGroup",
+      "GuHttpsEgressSecurityGroup",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -474,7 +475,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "SecurityGroups": [
               {
                 "Fn::GetAtt": [
-                  "EcsServiceSecurityGroup8FDFD52F",
+                  "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
                   "GroupId",
                 ],
               },
@@ -507,67 +508,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         },
       },
       "Type": "AWS::ECS::Service",
-    },
-    "EcsServiceSecurityGroup8FDFD52F": {
-      "DependsOn": [
-        "EcsTaskDefinitionTaskRoleB7B6D8DD",
-      ],
-      "Properties": {
-        "GroupDescription": "CdkPlayground-CODE/EcsService/SecurityGroup",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcIdParam",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "EcsServiceSecurityGroupfromCdkPlaygroundCODELoadBalancerCdkplaygroundSecurityGroup0DBDF6109000264BBAE2": {
-      "DependsOn": [
-        "EcsTaskDefinitionTaskRoleB7B6D8DD",
-      ],
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "EcsServiceSecurityGroup8FDFD52F",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "EcsTargetGroupCdkplaygroundecsF5A8D17A": {
       "Properties": {
@@ -922,6 +862,67 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcIdParam",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupCdkplaygroundecsfromCdkPlaygroundCODELoadBalancerCdkplaygroundSecurityGroup0DBDF61090001E6FD15F": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
     "GuHttpsEgressSecurityGroupCdkplaygroundfromCdkPlaygroundCODELoadBalancerCdkplaygroundSecurityGroup0DBDF6109000EA378CBA": {
       "Properties": {
         "Description": "Load balancer to target",
@@ -1185,12 +1186,12 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEEcsServiceSecurityGroup0CE266049000AE7040B8": {
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEGuHttpsEgressSecurityGroupCdkplayground610B4DD790000DEACC63": {
       "Properties": {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
-            "EcsServiceSecurityGroup8FDFD52F",
+            "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
             "GroupId",
           ],
         },
@@ -1206,12 +1207,12 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEGuHttpsEgressSecurityGroupCdkplayground610B4DD790000DEACC63": {
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEGuHttpsEgressSecurityGroupCdkplaygroundecsA834682C900045F0D1E9": {
       "Properties": {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
+            "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
             "GroupId",
           ],
         },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -589,7 +589,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
-        "HealthCheckPort": "9000",
         "HealthCheckTimeoutSeconds": 5,
         "HealthyThresholdCount": 5,
         "Port": 80,

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -29,9 +29,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuParameter",
       "GuParameter",
       "GuParameter",
-      "GuCertificate",
       "GuParameterStoreReadPolicy",
-      "GuCname",
       "GuApiLambda",
       "GuCertificate",
       "GuCname",
@@ -43,30 +41,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     "AutoscalingGroupName": {
       "Value": {
         "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
-      },
-    },
-    "FargateServiceWithClusterLoadBalancerDNS13D5ADEE": {
-      "Value": {
-        "Fn::GetAtt": [
-          "FargateServiceWithClusterLBC0F3A1A2",
-          "DNSName",
-        ],
-      },
-    },
-    "FargateServiceWithClusterServiceURLA598AD71": {
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            "https://",
-            {
-              "Fn::GetAtt": [
-                "FargateServiceWithClusterLBC0F3A1A2",
-                "DNSName",
-              ],
-            },
-          ],
-        ],
       },
     },
     "LoadBalancerCdkplaygroundDnsName": {
@@ -362,41 +336,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
     },
-    "CertificateCdkplaygroundecsD6C69B43": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "DomainName": "cdk-playground-ecs.code.dev-gutools.co.uk",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "cdk-playground-ecs",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Name",
-            "Value": "CdkPlayground-CODE/CertificateCdkplaygroundecs",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
-    },
     "CertificateCdkplaygroundlambda82D0BE4D": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -475,7 +414,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
-    "EcsDefaultClusterMnL3mNNYNVpc18E0451A": {
+    "EcsCluster97242B84": {
       "Properties": {
         "Tags": [
           {
@@ -498,42 +437,50 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::ECS::Cluster",
     },
-    "EcsDns": {
+    "EcsService81FC6EF6": {
+      "DependsOn": [
+        "EcsTaskDefinitionTaskRoleB7B6D8DD",
+      ],
       "Properties": {
-        "Name": "cdk-playground-ecs.code.dev-gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": [
+        "Cluster": {
+          "Ref": "EcsCluster97242B84",
+        },
+        "DeploymentConfiguration": {
+          "Alarms": {
+            "AlarmNames": [],
+            "Enable": false,
+            "Rollback": false,
+          },
+          "MaximumPercent": 200,
+          "MinimumHealthyPercent": 50,
+        },
+        "EnableECSManagedTags": false,
+        "HealthCheckGracePeriodSeconds": 60,
+        "LaunchType": "FARGATE",
+        "LoadBalancers": [
           {
-            "Fn::GetAtt": [
-              "FargateServiceWithClusterLBC0F3A1A2",
-              "DNSName",
+            "ContainerName": "cdk-playground",
+            "ContainerPort": 9000,
+            "TargetGroupArn": {
+              "Ref": "EcsTargetGroup06D481F9",
+            },
+          },
+        ],
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": [
+              {
+                "Fn::GetAtt": [
+                  "EcsServiceSecurityGroup8FDFD52F",
+                  "GroupId",
+                ],
+              },
             ],
+            "Subnets": {
+              "Ref": "VpcPrivateParam",
+            },
           },
-        ],
-        "Stage": "CODE",
-        "TTL": 60,
-      },
-      "Type": "Guardian::DNS::RecordSet",
-    },
-    "FargateServiceWithClusterLBC0F3A1A2": {
-      "Properties": {
-        "LoadBalancerAttributes": [
-          {
-            "Key": "deletion_protection.enabled",
-            "Value": "false",
-          },
-        ],
-        "Scheme": "internet-facing",
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "FargateServiceWithClusterLBSecurityGroupC2837562",
-              "GroupId",
-            ],
-          },
-        ],
-        "Subnets": {
-          "Ref": "VpcPublicParam",
         },
         "Tags": [
           {
@@ -553,42 +500,56 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
             "Value": "CODE",
           },
         ],
-        "Type": "application",
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    },
-    "FargateServiceWithClusterLBPublicListenerC7225768": {
-      "Properties": {
-        "Certificates": [
-          {
-            "CertificateArn": {
-              "Ref": "CertificateCdkplaygroundecsD6C69B43",
-            },
-          },
-        ],
-        "DefaultActions": [
-          {
-            "TargetGroupArn": {
-              "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
-            },
-            "Type": "forward",
-          },
-        ],
-        "LoadBalancerArn": {
-          "Ref": "FargateServiceWithClusterLBC0F3A1A2",
+        "TaskDefinition": {
+          "Ref": "EcsTaskDefinition63157ED3",
         },
-        "Port": 443,
-        "Protocol": "HTTPS",
       },
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Type": "AWS::ECS::Service",
     },
-    "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8": {
+    "EcsServiceSecurityGroup8FDFD52F": {
+      "DependsOn": [
+        "EcsTaskDefinitionTaskRoleB7B6D8DD",
+      ],
+      "Properties": {
+        "GroupDescription": "CdkPlayground-CODE/EcsService/SecurityGroup",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcIdParam",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "EcsTargetGroup06D481F9": {
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
         "HealthCheckTimeoutSeconds": 5,
         "HealthyThresholdCount": 5,
-        "Port": 80,
+        "Port": 9000,
         "Protocol": "HTTP",
         "Tags": [
           {
@@ -622,196 +583,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "FargateServiceWithClusterLBSecurityGroupC2837562": {
-      "Properties": {
-        "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundCODEFargateServiceWithClusterLB0054D6CB",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 443",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcIdParam",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "FargateServiceWithClusterLBSecurityGrouptoCdkPlaygroundCODEFargateServiceWithClusterServiceSecurityGroup9E89F2FB9000E419D184": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "FargateServiceWithClusterServiceSecurityGroupC199044E",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "FargateServiceWithClusterLBSecurityGroupC2837562",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "FargateServiceWithClusterServiceEC3A63FF": {
-      "DependsOn": [
-        "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
-        "FargateServiceWithClusterLBPublicListenerC7225768",
-        "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
-      ],
-      "Properties": {
-        "Cluster": {
-          "Ref": "EcsDefaultClusterMnL3mNNYNVpc18E0451A",
-        },
-        "DeploymentConfiguration": {
-          "Alarms": {
-            "AlarmNames": [],
-            "Enable": false,
-            "Rollback": false,
-          },
-          "MaximumPercent": 200,
-          "MinimumHealthyPercent": 50,
-        },
-        "EnableECSManagedTags": false,
-        "HealthCheckGracePeriodSeconds": 60,
-        "LaunchType": "FARGATE",
-        "LoadBalancers": [
-          {
-            "ContainerName": "cdk-playground",
-            "ContainerPort": 9000,
-            "TargetGroupArn": {
-              "Ref": "FargateServiceWithClusterLBPublicListenerECSGroupC7B6A4A8",
-            },
-          },
-        ],
-        "NetworkConfiguration": {
-          "AwsvpcConfiguration": {
-            "AssignPublicIp": "DISABLED",
-            "SecurityGroups": [
-              {
-                "Fn::GetAtt": [
-                  "FargateServiceWithClusterServiceSecurityGroupC199044E",
-                  "GroupId",
-                ],
-              },
-            ],
-            "Subnets": {
-              "Ref": "VpcPrivateParam",
-            },
-          },
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "TaskDefinition": {
-          "Ref": "FargateServiceWithClusterTaskDefADD1A9C3",
-        },
-      },
-      "Type": "AWS::ECS::Service",
-    },
-    "FargateServiceWithClusterServiceSecurityGroupC199044E": {
-      "DependsOn": [
-        "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
-      ],
-      "Properties": {
-        "GroupDescription": "CdkPlayground-CODE/FargateServiceWithCluster/Service/SecurityGroup",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcIdParam",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "FargateServiceWithClusterServiceSecurityGroupfromCdkPlaygroundCODEFargateServiceWithClusterLBSecurityGroup8854CFAF900044BA2FDA": {
-      "DependsOn": [
-        "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
-      ],
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "FargateServiceWithClusterServiceSecurityGroupC199044E",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "FargateServiceWithClusterLBSecurityGroupC2837562",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "FargateServiceWithClusterTaskDefADD1A9C3": {
+    "EcsTaskDefinition63157ED3": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -835,10 +607,10 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
               "LogDriver": "awslogs",
               "Options": {
                 "awslogs-group": {
-                  "Ref": "FargateServiceWithClusterTaskDefcdkplaygroundLogGroup4AEF846A",
+                  "Ref": "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754",
                 },
                 "awslogs-region": "eu-west-1",
-                "awslogs-stream-prefix": "FargateServiceWithCluster",
+                "awslogs-stream-prefix": "cdk-playground-ecs",
               },
             },
             "Name": "cdk-playground",
@@ -853,11 +625,11 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "Cpu": "256",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
-            "FargateServiceWithClusterTaskDefExecutionRole4ED71D3B",
+            "EcsTaskDefinitionExecutionRoleBE450C73",
             "Arn",
           ],
         },
-        "Family": "CdkPlaygroundCODEFargateServiceWithClusterTaskDef754180B4",
+        "Family": "CdkPlaygroundCODEEcsTaskDefinition427433B1",
         "Memory": "512",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
@@ -883,14 +655,14 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         ],
         "TaskRoleArn": {
           "Fn::GetAtt": [
-            "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
+            "EcsTaskDefinitionTaskRoleB7B6D8DD",
             "Arn",
           ],
         },
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
-    "FargateServiceWithClusterTaskDefExecutionRole4ED71D3B": {
+    "EcsTaskDefinitionExecutionRoleBE450C73": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -925,7 +697,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "FargateServiceWithClusterTaskDefExecutionRoleDefaultPolicy390D6692": {
+    "EcsTaskDefinitionExecutionRoleDefaultPolicy1611A942": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -966,7 +738,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "FargateServiceWithClusterTaskDefcdkplaygroundLogGroup4AEF846A",
+                  "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754",
                   "Arn",
                 ],
               },
@@ -974,16 +746,16 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "FargateServiceWithClusterTaskDefExecutionRoleDefaultPolicy390D6692",
+        "PolicyName": "EcsTaskDefinitionExecutionRoleDefaultPolicy1611A942",
         "Roles": [
           {
-            "Ref": "FargateServiceWithClusterTaskDefExecutionRole4ED71D3B",
+            "Ref": "EcsTaskDefinitionExecutionRoleBE450C73",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "FargateServiceWithClusterTaskDefTaskRole6DACF8B7": {
+    "EcsTaskDefinitionTaskRoleB7B6D8DD": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -1018,7 +790,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "FargateServiceWithClusterTaskDefcdkplaygroundLogGroup4AEF846A": {
+    "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754": {
       "DeletionPolicy": "Retain",
       "Properties": {
         "Tags": [
@@ -1242,8 +1014,21 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         ],
         "DefaultActions": [
           {
-            "TargetGroupArn": {
-              "Ref": "TargetGroupCdkplayground7A453FC2",
+            "ForwardConfig": {
+              "TargetGroups": [
+                {
+                  "TargetGroupArn": {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "Weight": 50,
+                },
+                {
+                  "TargetGroupArn": {
+                    "Ref": "EcsTargetGroup06D481F9",
+                  },
+                  "Weight": 50,
+                },
+              ],
             },
             "Type": "forward",
           },
@@ -1482,7 +1267,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "PolicyName": "parameter-store-read-policy",
         "Roles": [
           {
-            "Ref": "FargateServiceWithClusterTaskDefTaskRole6DACF8B7",
+            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -440,6 +440,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     "EcsService81FC6EF6": {
       "DependsOn": [
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
+        "ListenerCdkplaygroundA8D9CA6F",
       ],
       "Properties": {
         "Cluster": {
@@ -542,6 +543,30 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "EcsServiceSecurityGroupfromCdkPlaygroundCODELoadBalancerCdkplaygroundSecurityGroup0DBDF6109000264BBAE2": {
+      "DependsOn": [
+        "EcsTaskDefinitionTaskRoleB7B6D8DD",
+      ],
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "EcsServiceSecurityGroup8FDFD52F",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "EcsTargetGroup06D481F9": {
       "Properties": {
@@ -1149,6 +1174,27 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEEcsServiceSecurityGroup0CE266049000AE7040B8": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "EcsServiceSecurityGroup8FDFD52F",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEGuHttpsEgressSecurityGroupCdkplayground610B4DD790000DEACC63": {
       "Properties": {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -196,7 +196,7 @@ export class CdkPlayground extends GuStack {
 		);
 
 		// AWS::ElasticLoadBalancingV2::TargetGroup (can now be wired up with existing load balancer)
-		// TODO - can we use the GuCDK construct here?
+		// TODO - could we use the GuApplicationTargetGroup construct here?
 		const ecsTargetGroup = new ApplicationTargetGroup(this, 'EcsTargetGroup', {
 			vpc,
 			port: 9000,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -140,7 +140,7 @@ export class CdkPlayground extends GuStack {
 			'Vpc',
 			{
 				vpcId: vpcFromEc2AppPattern.vpcId,
-				// We have to provide public subnet ids to get passed a validation error, but they are unused
+				// We have to provide public subnet ids to avoid a validation error, but they are unused
 				publicSubnetIds: [''],
 				// This seems to be the important bit that is missing from the IVpc that the pattern provides
 				privateSubnetIds: privateSubnetIds.valueAsList,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -4,10 +4,7 @@ import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
-import {
-	GuParameterStoreReadPolicy,
-	GuRole,
-} from '@guardian/cdk/lib/constructs/iam';
+import { GuParameterStoreReadPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration } from 'aws-cdk-lib';
@@ -22,7 +19,6 @@ import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
 import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
 import { ApplicationProtocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -115,6 +115,7 @@ export class CdkPlayground extends GuStack {
 
 		const ecsApp = 'cdk-playground-ecs';
 
+		// The EC2 app pattern hides all of this VPC wiring for us
 		const vpcId = new GuParameter(this, 'VpcIdParam', {
 			fromSSM: true,
 			default: `/account/vpc/primary/id`,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -160,8 +160,8 @@ export class CdkPlayground extends GuStack {
 		});
 
 		// Potential Issues
-		// * Load balancer deletion protection is false
-		// * Allows all outbound traffic by default (should this be HTTPs only?)
+		// * Load balancer deletion protection is false (to match pattern this should be true)
+		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
 		// * Target group port
 		// * ECS health check grace period - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
 		// * Target group health checks?

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -178,6 +178,7 @@ export class CdkPlayground extends GuStack {
 				// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
 				taskImageOptions: {
 					image,
+					containerName: 'cdk-playground',
 					containerPort: 9000,
 				},
 			},

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -159,9 +159,7 @@ export class CdkPlayground extends GuStack {
 		// the simple case where the app and the repo are both in Deploy Tools
 		const image = ContainerImage.fromEcrRepository(
 			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
-			// Hardcode this for now so that we have an image to test with; this should really point to the build identifier
-			'bd1737b461371a7e956eae24f12188946946c55f',
-			// buildIdentifier,
+			`build-${buildIdentifier}`,
 		);
 
 		// AWS::ECS::TaskDefinition

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -196,6 +196,7 @@ export class CdkPlayground extends GuStack {
 		);
 
 		// AWS::ElasticLoadBalancingV2::TargetGroup (can now be wired up with existing load balancer)
+		// TODO - can we use the GuCDK construct here?
 		const ecsTargetGroup = new ApplicationTargetGroup(this, 'EcsTargetGroup', {
 			vpc,
 			port: 9000,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -4,6 +4,7 @@ import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuHttpsEgressSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
 import { GuParameterStoreReadPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuApplicationTargetGroup } from '@guardian/cdk/lib/constructs/loadbalancing';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
@@ -164,7 +165,6 @@ export class CdkPlayground extends GuStack {
 
 		// ## Potential ECS Issues
 		// * Load balancer deletion protection is false (to match pattern this should be true)
-		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
 		// * Logging - ships to CloudWatch by default and https://github.com/guardian/cloudwatch-logs-management can be
 		//   configured to pick up from there
 		// * Deployment?
@@ -203,10 +203,16 @@ export class CdkPlayground extends GuStack {
 		);
 
 		// AWS::ECS::Service
-		// AWS::EC2::SecurityGroup (this is what's allowing outbound traffic by default)
 		const ecsService = new FargateService(this, 'EcsService', {
 			cluster,
 			taskDefinition,
+			// By default, AWS will create a new security group which allows all outbound traffic
+			// We don't want this so explicitly allow outbound HTTPS only
+			// This is what we do for the current GuEc2App pattern:
+			// https://github.com/guardian/cdk/blob/3b5688637024642055ed0bf576f668e56e40830d/src/constructs/autoscaling/asg.ts#L143-L145
+			securityGroups: [
+				GuHttpsEgressSecurityGroup.forVpc(this, { app: ecsApp, vpc }),
+			],
 		});
 
 		ecsTargetGroup.addTarget(ecsService);

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -183,6 +183,7 @@ export class CdkPlayground extends GuStack {
 		);
 
 		loadBalancedEcs.targetGroup.configureHealthCheck({
+			port: '9000',
 			path: '/healthcheck',
 			interval: Duration.seconds(10),
 			timeout: Duration.seconds(5),

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -204,15 +204,6 @@ export class CdkPlayground extends GuStack {
 				vpc,
 				app: ecsApp,
 				port: 9000,
-				protocol: ApplicationProtocol.HTTP,
-				targetType: TargetType.IP,
-				healthCheck: {
-					path: '/healthcheck',
-					interval: Duration.seconds(10),
-					timeout: Duration.seconds(5),
-					healthyThresholdCount: 5,
-					unhealthyThresholdCount: 2,
-				},
 			},
 		);
 

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -164,7 +164,6 @@ export class CdkPlayground extends GuStack {
 		// Potential Issues
 		// * Load balancer deletion protection is false (to match pattern this should be true)
 		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
-		// * ECS health check grace period - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
 		// * IAM roles / permissions?
 		// * Logging?
 		// * Deployment?
@@ -175,6 +174,8 @@ export class CdkPlayground extends GuStack {
 				vpc,
 				protocol: ApplicationProtocol.HTTPS,
 				certificate,
+				// healthCheckGracePeriod - should we define this? AWS CDK is defaulting to 1 minute
+				// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
 				taskImageOptions: {
 					image,
 					containerPort: 9000,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -151,7 +151,9 @@ export class CdkPlayground extends GuStack {
 		// the simple case where the app and the repo are both in Deploy Tools
 		const image = ContainerImage.fromEcrRepository(
 			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
-			buildIdentifier,
+			// Hardcode this for now so that we have an image to test with; this should really point to the right build number
+			'bd1737b461371a7e956eae24f12188946946c55f',
+			// buildIdentifier,
 		);
 
 		const certificate = new GuCertificate(this, {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -145,11 +145,12 @@ export class CdkPlayground extends GuStack {
 		// the simple case where the app and the repo are both in Deploy Tools
 		const image = ContainerImage.fromEcrRepository(
 			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
-			// Hardcode this for now so that we have an image to test with; this should really point to the right build number
+			// Hardcode this for now so that we have an image to test with; this should really point to the build identifier
 			'bd1737b461371a7e956eae24f12188946946c55f',
 			// buildIdentifier,
 		);
 
+		// EC2 app pattern creates this for us
 		const certificate = new GuCertificate(this, {
 			app: ecsApp,
 			domainName: ecsDomainName,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -184,7 +184,6 @@ export class CdkPlayground extends GuStack {
 		);
 
 		loadBalancedEcs.targetGroup.configureHealthCheck({
-			port: '9000',
 			path: '/healthcheck',
 			interval: Duration.seconds(10),
 			timeout: Duration.seconds(5),

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -2,13 +2,18 @@ import { GuApiLambda } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuParameter } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration } from 'aws-cdk-lib';
 import { CfnScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
+import { Vpc } from 'aws-cdk-lib/aws-ec2';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { Repository } from 'aws-cdk-lib/aws-ecr';
+import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
+import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
@@ -65,6 +70,57 @@ export class CdkPlayground extends GuStack {
 			imageRecipe: 'arm64-jammy-java21-deploy-infrastructure',
 			instanceMetricGranularity: '5Minute',
 		});
+
+		const vpcId = new GuParameter(this, 'VpcIdParam', {
+			fromSSM: true,
+			default: `/account/vpc/primary/id`,
+			description: 'The VPC to deploy the structuriser to',
+		});
+
+		const publicSubnetIds = new GuParameter(this, 'VpcPublicParam', {
+			fromSSM: true,
+			default: '/account/vpc/primary/subnets/public',
+			type: 'List<String>',
+		});
+
+		const privateSubnetIds = new GuParameter(this, 'VpcPrivateParam', {
+			fromSSM: true,
+			default: '/account/vpc/primary/subnets/private',
+			type: 'List<String>',
+		});
+
+		const availabilityZones = new GuParameter(this, 'VpcAZParam', {
+			fromSSM: true,
+			default: '/account/vpc/primary/availability-zones',
+			type: 'List<String>',
+		});
+
+		// Trying to use the vpc that is available via the pattern fails with the following error:
+		// ValidationError: There are no 'Public' subnet groups in this VPC. Available types:
+		const vpc = Vpc.fromVpcAttributes(this, 'Vpc', {
+			vpcId: vpcId.valueAsString,
+			publicSubnetIds: publicSubnetIds.valueAsList,
+			privateSubnetIds: privateSubnetIds.valueAsList,
+			availabilityZones: availabilityZones.valueAsList,
+		});
+
+		// Need to figure out how to make this cross-account, but this is fine for
+		// the simple case where the app and the repo are both in Deploy Tools
+		const image = ContainerImage.fromEcrRepository(
+			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
+			buildIdentifier,
+		);
+
+		new ApplicationLoadBalancedFargateService(
+			this,
+			'FargateServiceWithCluster',
+			{
+				vpc,
+				taskImageOptions: {
+					image,
+				},
+			},
+		);
 
 		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {
 			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -5,6 +5,7 @@ import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuParameterStoreReadPolicy } from '@guardian/cdk/lib/constructs/iam';
+import { GuApplicationTargetGroup } from '@guardian/cdk/lib/constructs/loadbalancing';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration } from 'aws-cdk-lib';
@@ -196,20 +197,24 @@ export class CdkPlayground extends GuStack {
 		);
 
 		// AWS::ElasticLoadBalancingV2::TargetGroup (can now be wired up with existing load balancer)
-		// TODO - could we use the GuApplicationTargetGroup construct here?
-		const ecsTargetGroup = new ApplicationTargetGroup(this, 'EcsTargetGroup', {
-			vpc,
-			port: 9000,
-			protocol: ApplicationProtocol.HTTP,
-			targetType: TargetType.IP,
-			healthCheck: {
-				path: '/healthcheck',
-				interval: Duration.seconds(10),
-				timeout: Duration.seconds(5),
-				healthyThresholdCount: 5,
-				unhealthyThresholdCount: 2,
+		const ecsTargetGroup = new GuApplicationTargetGroup(
+			this,
+			'EcsTargetGroup',
+			{
+				vpc,
+				app: ecsApp,
+				port: 9000,
+				protocol: ApplicationProtocol.HTTP,
+				targetType: TargetType.IP,
+				healthCheck: {
+					path: '/healthcheck',
+					interval: Duration.seconds(10),
+					timeout: Duration.seconds(5),
+					healthyThresholdCount: 5,
+					unhealthyThresholdCount: 2,
+				},
 			},
-		});
+		);
 
 		// AWS::ECS::Service
 		// AWS::EC2::SecurityGroup (this is what's allowing outbound traffic by default)

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -2,18 +2,22 @@ import { GuApiLambda } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuParameter } from '@guardian/cdk/lib/constructs/core';
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration } from 'aws-cdk-lib';
 import { CfnScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
-import { Vpc } from 'aws-cdk-lib/aws-ec2';
-import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import {
+	InstanceClass,
+	InstanceSize,
+	InstanceType,
+	Vpc,
+} from 'aws-cdk-lib/aws-ec2';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
 import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
+import { ApplicationProtocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
@@ -39,6 +43,7 @@ export class CdkPlayground extends GuStack {
 		const { buildIdentifier } = props;
 
 		const ec2AppDomainName = 'cdk-playground.code.dev-gutools.co.uk';
+		const ecsDomainName = 'cdk-playground-ecs.code.dev-gutools.co.uk';
 		const lambdaDomainName = 'cdk-playground-lambda.code.dev-gutools.co.uk';
 
 		const ec2App = 'cdk-playground';
@@ -70,6 +75,44 @@ export class CdkPlayground extends GuStack {
 			imageRecipe: 'arm64-jammy-java21-deploy-infrastructure',
 			instanceMetricGranularity: '5Minute',
 		});
+
+		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {
+			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
+			policyType: 'SimpleScaling',
+			adjustmentType: 'ChangeInCapacity',
+			scalingAdjustment: 1,
+		});
+
+		const scaleInPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleIn', {
+			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
+			policyType: 'SimpleScaling',
+			adjustmentType: 'ChangeInCapacity',
+			scalingAdjustment: -1,
+		});
+
+		new CfnOutput(this, 'ScaleOutArn', {
+			key: 'ScaleOutArn',
+			value: scaleOutPolicy.attrArn,
+		});
+
+		new CfnOutput(this, 'ScaleInArn', {
+			key: 'ScaleInArn',
+			value: scaleInPolicy.attrArn,
+		});
+
+		new CfnOutput(this, 'AutoscalingGroupName', {
+			key: 'AutoscalingGroupName',
+			value: autoScalingGroup.autoScalingGroupName,
+		});
+
+		new GuCname(this, 'EC2AppDNS', {
+			app: ec2App,
+			ttl: Duration.hours(1),
+			domainName: ec2AppDomainName,
+			resourceRecord: loadBalancer.loadBalancerDnsName,
+		});
+
+		const ecsApp = 'cdk-playground-ecs';
 
 		const vpcId = new GuParameter(this, 'VpcIdParam', {
 			fromSSM: true,
@@ -111,51 +154,39 @@ export class CdkPlayground extends GuStack {
 			buildIdentifier,
 		);
 
-		new ApplicationLoadBalancedFargateService(
+		const certificate = new GuCertificate(this, {
+			app: ecsApp,
+			domainName: ecsDomainName,
+		});
+
+		// Potential Issues
+		// * Load balancer deletion protection is false
+		// * Allows all outbound traffic by default (should this be HTTPs only?)
+		// * Target group port
+		// * ECS health check grace period - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
+		// * Target group health checks?
+		// * IAM roles / permissions?
+		// * Logging?
+		// * Deployment?
+		const loadBalancedEcs = new ApplicationLoadBalancedFargateService(
 			this,
 			'FargateServiceWithCluster',
 			{
 				vpc,
+				protocol: ApplicationProtocol.HTTPS,
+				certificate,
 				taskImageOptions: {
 					image,
 				},
 			},
 		);
 
-		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {
-			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
-			policyType: 'SimpleScaling',
-			adjustmentType: 'ChangeInCapacity',
-			scalingAdjustment: 1,
-		});
-
-		const scaleInPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleIn', {
-			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
-			policyType: 'SimpleScaling',
-			adjustmentType: 'ChangeInCapacity',
-			scalingAdjustment: -1,
-		});
-
-		new CfnOutput(this, 'ScaleOutArn', {
-			key: 'ScaleOutArn',
-			value: scaleOutPolicy.attrArn,
-		});
-
-		new CfnOutput(this, 'ScaleInArn', {
-			key: 'ScaleInArn',
-			value: scaleInPolicy.attrArn,
-		});
-
-		new CfnOutput(this, 'AutoscalingGroupName', {
-			key: 'AutoscalingGroupName',
-			value: autoScalingGroup.autoScalingGroupName,
-		});
-
-		new GuCname(this, 'EC2AppDNS', {
-			app: ec2App,
-			ttl: Duration.hours(1),
-			domainName: ec2AppDomainName,
-			resourceRecord: loadBalancer.loadBalancerDnsName,
+		// Let's create a separate GuCname for now, but we could use the existing one to perform a migration if desired
+		new GuCname(this, 'EcsDns', {
+			app: ecsApp,
+			ttl: Duration.minutes(1),
+			domainName: ecsDomainName,
+			resourceRecord: loadBalancedEcs.loadBalancer.loadBalancerDnsName,
 		});
 
 		const lambdaApp = 'cdk-playground-lambda';

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -132,19 +132,13 @@ export class CdkPlayground extends GuStack {
 			type: 'List<String>',
 		});
 
-		const availabilityZones = new GuParameter(this, 'VpcAZParam', {
-			fromSSM: true,
-			default: '/account/vpc/primary/availability-zones',
-			type: 'List<String>',
-		});
-
 		// Trying to use the vpc that is available via the pattern fails with the following error:
 		// ValidationError: There are no 'Public' subnet groups in this VPC. Available types:
 		const vpc = Vpc.fromVpcAttributes(this, 'Vpc', {
 			vpcId: vpcId.valueAsString,
 			publicSubnetIds: publicSubnetIds.valueAsList,
 			privateSubnetIds: privateSubnetIds.valueAsList,
-			availabilityZones: availabilityZones.valueAsList,
+			availabilityZones: [''], // The type system forces us to provide this but it doesn't actually seem to be needed
 		});
 
 		// Need to figure out how to make this cross-account, but this is fine for

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -4,6 +4,10 @@ import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import {
+	GuParameterStoreReadPolicy,
+	GuRole,
+} from '@guardian/cdk/lib/constructs/iam';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, Duration } from 'aws-cdk-lib';
@@ -18,6 +22,7 @@ import { Repository } from 'aws-cdk-lib/aws-ecr';
 import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
 import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
 import { ApplicationProtocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
@@ -156,12 +161,25 @@ export class CdkPlayground extends GuStack {
 			domainName: ecsDomainName,
 		});
 
-		// Potential Issues
+		// ## Potential Issues
 		// * Load balancer deletion protection is false (to match pattern this should be true)
 		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
-		// * IAM roles / permissions?
 		// * Logging?
 		// * Deployment?
+		//
+		// ## CFN resources
+		// AWS::ECS::Cluster (can pass in your own)
+		// AWS::ECS::Service
+		// AWS::ECS::TaskDefinition
+		// AWS::Logs::LogGroup
+		// AWS::IAM::Role ('execution role' - used for pulling image etc. - can pass in your own)
+		// AWS::IAM::Role ('task role' - used for application's runtime permissions e.g. reading config from SSM - can pass in your own)
+		// AWS::IAM::Policy
+		// AWS::ElasticLoadBalancingV2::LoadBalancer (present in GuEc2App; no need to duplicate)
+		// AWS::ElasticLoadBalancingV2::Listener (present in GuEc2App; no need to duplicate)
+		// AWS::ElasticLoadBalancingV2::TargetGroup (present in GuEc2App; need new dedicated group)
+		// AWS::EC2::SecurityGroups and AWS::EC2::SecurityGroupEgress / AWS::EC2::SecurityGroupIngress (from memory, aws-cdk auto-generates these anyway)
+
 		const loadBalancedEcs = new ApplicationLoadBalancedFargateService(
 			this,
 			'FargateServiceWithCluster',
@@ -177,6 +195,11 @@ export class CdkPlayground extends GuStack {
 					containerPort: 9000,
 				},
 			},
+		);
+
+		// EC2 pattern helps with this wiring and provides useful default permissions, although most of these are irrelevant when running in ECS
+		new GuParameterStoreReadPolicy(this, { app: ecsApp }).attachToRole(
+			loadBalancedEcs.taskDefinition.taskRole,
 		);
 
 		loadBalancedEcs.targetGroup.configureHealthCheck({

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -223,9 +223,13 @@ export class CdkPlayground extends GuStack {
 
 		// If we build this into the pattern we should be able to modify GuHttpsApplicationListener to do something
 		// along these lines but in a cleaner way
+
+		// This creates the requisite ingress/egress rules between the load balancer and the targets
 		listener.addTargetGroups('AddEcsTargetGroup', {
 			targetGroups: [ecsTargetGroup],
 		});
+
+		// And this splits the traffic evenly between EC2 and ECS
 		const cfnListener = listener.node.defaultChild as CfnListener;
 		cfnListener.defaultActions = [
 			{

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -163,7 +163,6 @@ export class CdkPlayground extends GuStack {
 		// * Load balancer deletion protection is false (to match pattern this should be true)
 		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
 		// * ECS health check grace period - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
-		// * Target group health checks?
 		// * IAM roles / permissions?
 		// * Logging?
 		// * Deployment?
@@ -180,6 +179,14 @@ export class CdkPlayground extends GuStack {
 				},
 			},
 		);
+
+		loadBalancedEcs.targetGroup.configureHealthCheck({
+			path: '/healthcheck',
+			interval: Duration.seconds(10),
+			timeout: Duration.seconds(5),
+			healthyThresholdCount: 5,
+			unhealthyThresholdCount: 2,
+		});
 
 		// Let's create a separate GuCname for now, but we could use the existing one to perform a migration if desired
 		new GuCname(this, 'EcsDns', {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -220,7 +220,11 @@ export class CdkPlayground extends GuStack {
 
 		ecsTargetGroup.addTarget(ecsService);
 
-		// In the future we could do this within the pattern code, so we wouldn't need escape hatches
+		// If we build this into the pattern we should be able to modify GuHttpsApplicationListener to do something
+		// along these lines but in a cleaner way
+		listener.addTargetGroups('AddEcsTargetGroup', {
+			targetGroups: [ecsTargetGroup],
+		});
 		const cfnListener = listener.node.defaultChild as CfnListener;
 		cfnListener.defaultActions = [
 			{

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -16,9 +16,19 @@ import {
 	Vpc,
 } from 'aws-cdk-lib/aws-ec2';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
-import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
-import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
-import { ApplicationProtocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import {
+	Cluster,
+	ContainerImage,
+	FargateService,
+	FargateTaskDefinition,
+	LogDriver,
+} from 'aws-cdk-lib/aws-ecs';
+import type { CfnListener } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import {
+	ApplicationProtocol,
+	ApplicationTargetGroup,
+	TargetType,
+} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
@@ -44,12 +54,16 @@ export class CdkPlayground extends GuStack {
 		const { buildIdentifier } = props;
 
 		const ec2AppDomainName = 'cdk-playground.code.dev-gutools.co.uk';
-		const ecsDomainName = 'cdk-playground-ecs.code.dev-gutools.co.uk';
 		const lambdaDomainName = 'cdk-playground-lambda.code.dev-gutools.co.uk';
 
 		const ec2App = 'cdk-playground';
 
-		const { loadBalancer, autoScalingGroup } = new GuEc2AppExperimental(this, {
+		const {
+			loadBalancer,
+			autoScalingGroup,
+			listener,
+			targetGroup: ec2TargetGroup,
+		} = new GuEc2AppExperimental(this, {
 			buildIdentifier,
 			applicationPort: 9000,
 			app: ec2App,
@@ -152,69 +166,78 @@ export class CdkPlayground extends GuStack {
 			// buildIdentifier,
 		);
 
-		// EC2 app pattern creates this for us
-		const certificate = new GuCertificate(this, {
-			app: ecsApp,
-			domainName: ecsDomainName,
-		});
-
-		// ## Potential Issues
+		// ## Potential ECS Issues
 		// * Load balancer deletion protection is false (to match pattern this should be true)
 		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
 		// * Logging - ships to CloudWatch by default and https://github.com/guardian/cloudwatch-logs-management can be
 		//   configured to pick up from there
 		// * Deployment?
-		//
-		// ## CFN resources
-		// AWS::ECS::Cluster (can pass in your own)
-		// AWS::ECS::Service
-		// AWS::ECS::TaskDefinition
-		// AWS::Logs::LogGroup
-		// AWS::IAM::Role ('execution role' - used for pulling image etc. - can pass in your own)
-		// AWS::IAM::Role ('task role' - used for application's runtime permissions e.g. reading config from SSM - can pass in your own)
-		// AWS::IAM::Policy
-		// AWS::ElasticLoadBalancingV2::LoadBalancer (present in GuEc2App; no need to duplicate)
-		// AWS::ElasticLoadBalancingV2::Listener (present in GuEc2App; no need to duplicate)
-		// AWS::ElasticLoadBalancingV2::TargetGroup (present in GuEc2App; need new dedicated group)
-		// AWS::EC2::SecurityGroups and AWS::EC2::SecurityGroupEgress / AWS::EC2::SecurityGroupIngress (from memory, aws-cdk auto-generates these anyway)
 
-		const loadBalancedEcs = new ApplicationLoadBalancedFargateService(
-			this,
-			'FargateServiceWithCluster',
-			{
-				vpc,
-				protocol: ApplicationProtocol.HTTPS,
-				certificate,
-				// healthCheckGracePeriod - should we define this? AWS CDK is defaulting to 1 minute
-				// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
-				taskImageOptions: {
-					image,
-					containerName: 'cdk-playground',
-					containerPort: 9000,
-				},
-			},
-		);
+		// AWS::ECS::Cluster
+		const cluster = new Cluster(this, 'EcsCluster', { vpc });
+
+		// AWS::ECS::TaskDefinition
+		// AWS::IAM::Role ('execution role' - used for pulling image etc.)
+		// AWS::IAM::Role ('task role' - used for application's runtime permissions e.g. reading config from SSM)
+		const taskDefinition = new FargateTaskDefinition(this, 'EcsTaskDefinition');
+
+		taskDefinition.addContainer('cdk-playground', {
+			image,
+			portMappings: [{ containerPort: 9000 }],
+			// AWS::Logs::LogGroup
+			logging: LogDriver.awsLogs({
+				streamPrefix: 'cdk-playground-ecs',
+			}),
+		});
 
 		// EC2 pattern helps with this wiring and provides useful default permissions, although most of these are irrelevant when running in ECS
 		new GuParameterStoreReadPolicy(this, { app: ecsApp }).attachToRole(
-			loadBalancedEcs.taskDefinition.taskRole,
+			taskDefinition.taskRole,
 		);
 
-		loadBalancedEcs.targetGroup.configureHealthCheck({
-			path: '/healthcheck',
-			interval: Duration.seconds(10),
-			timeout: Duration.seconds(5),
-			healthyThresholdCount: 5,
-			unhealthyThresholdCount: 2,
+		// AWS::ElasticLoadBalancingV2::TargetGroup (can now be wired up with existing load balancer)
+		const ecsTargetGroup = new ApplicationTargetGroup(this, 'EcsTargetGroup', {
+			vpc,
+			port: 9000,
+			protocol: ApplicationProtocol.HTTP,
+			targetType: TargetType.IP,
+			healthCheck: {
+				path: '/healthcheck',
+				interval: Duration.seconds(10),
+				timeout: Duration.seconds(5),
+				healthyThresholdCount: 5,
+				unhealthyThresholdCount: 2,
+			},
 		});
 
-		// Let's create a separate GuCname for now, but we could use the existing one to perform a migration if desired
-		new GuCname(this, 'EcsDns', {
-			app: ecsApp,
-			ttl: Duration.minutes(1),
-			domainName: ecsDomainName,
-			resourceRecord: loadBalancedEcs.loadBalancer.loadBalancerDnsName,
+		// AWS::ECS::Service
+		// AWS::EC2::SecurityGroup (this is what's allowing outbound traffic by default)
+		const ecsService = new FargateService(this, 'EcsService', {
+			cluster,
+			taskDefinition,
 		});
+
+		ecsTargetGroup.addTarget(ecsService);
+
+		// In the future we could do this within the pattern code, so we wouldn't need escape hatches
+		const cfnListener = listener.node.defaultChild as CfnListener;
+		cfnListener.defaultActions = [
+			{
+				type: 'forward',
+				forwardConfig: {
+					targetGroups: [
+						{
+							targetGroupArn: ec2TargetGroup.targetGroupArn,
+							weight: 50,
+						},
+						{
+							targetGroupArn: ecsTargetGroup.targetGroupArn,
+							weight: 50,
+						},
+					],
+				},
+			},
+		];
 
 		const lambdaApp = 'cdk-playground-lambda';
 

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -56,10 +56,11 @@ export class CdkPlayground extends GuStack {
 		const ec2App = 'cdk-playground';
 
 		const {
-			loadBalancer,
 			autoScalingGroup,
 			listener,
+			loadBalancer,
 			targetGroup: ec2TargetGroup,
+			vpc: vpcFromEc2AppPattern,
 		} = new GuEc2AppExperimental(this, {
 			buildIdentifier,
 			applicationPort: 9000,
@@ -145,13 +146,22 @@ export class CdkPlayground extends GuStack {
 			type: 'List<String>',
 		});
 
-		// Trying to use the vpc that is available via the pattern fails with the following error:
-		// ValidationError: There are no 'Public' subnet groups in this VPC. Available types:
-		const vpc = Vpc.fromVpcAttributes(this, 'Vpc', {
-			vpcId: vpcId.valueAsString,
-			publicSubnetIds: publicSubnetIds.valueAsList,
-			privateSubnetIds: privateSubnetIds.valueAsList,
-			availabilityZones: [''], // The type system forces us to provide this but it doesn't actually seem to be needed
+		const vpcThatEcsClusterConstructWillAccept = Vpc.fromVpcAttributes(
+			this,
+			'Vpc',
+			{
+				vpcId: vpcId.valueAsString,
+				publicSubnetIds: publicSubnetIds.valueAsList,
+				privateSubnetIds: privateSubnetIds.valueAsList,
+				availabilityZones: [''], // The type system forces us to provide this, but it doesn't actually seem to be needed
+			},
+		);
+
+		// AWS::ECS::Cluster
+		const cluster = new Cluster(this, 'EcsCluster', {
+			// Trying to use vpcFromEc2AppPattern fails with the following error:
+			// ValidationError: There are no 'Public' subnet groups in this VPC. Available types:
+			vpc: vpcThatEcsClusterConstructWillAccept,
 		});
 
 		// Need to figure out how to make this cross-account, but this is fine for
@@ -162,14 +172,6 @@ export class CdkPlayground extends GuStack {
 			'bd1737b461371a7e956eae24f12188946946c55f',
 			// buildIdentifier,
 		);
-
-		// ## TODO
-		// * Logging - ships to CloudWatch by default and https://github.com/guardian/cloudwatch-logs-management can be
-		//   configured to pick up from there
-		// * Deployment?
-
-		// AWS::ECS::Cluster
-		const cluster = new Cluster(this, 'EcsCluster', { vpc });
 
 		// AWS::ECS::TaskDefinition
 		// AWS::IAM::Role ('execution role' - used for pulling image etc.)
@@ -195,7 +197,7 @@ export class CdkPlayground extends GuStack {
 			this,
 			'EcsTargetGroup',
 			{
-				vpc,
+				vpc: vpcFromEc2AppPattern,
 				app: ecsApp,
 				port: 9000,
 			},
@@ -210,7 +212,10 @@ export class CdkPlayground extends GuStack {
 			// This is what we do for the current GuEc2App pattern:
 			// https://github.com/guardian/cdk/blob/3b5688637024642055ed0bf576f668e56e40830d/src/constructs/autoscaling/asg.ts#L143-L145
 			securityGroups: [
-				GuHttpsEgressSecurityGroup.forVpc(this, { app: ecsApp, vpc }),
+				GuHttpsEgressSecurityGroup.forVpc(this, {
+					app: ecsApp,
+					vpc: vpcFromEc2AppPattern,
+				}),
 			],
 		});
 
@@ -239,6 +244,11 @@ export class CdkPlayground extends GuStack {
 				},
 			},
 		];
+
+		// ## TODO for ECS infrastructure
+		// * Logging - ships to CloudWatch by default and https://github.com/guardian/cloudwatch-logs-management can be
+		//   configured to pick up from there
+		// * Deployment?
 
 		const lambdaApp = 'cdk-playground-lambda';
 

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -127,31 +127,22 @@ export class CdkPlayground extends GuStack {
 
 		const ecsApp = 'cdk-playground-ecs';
 
-		// The EC2 app pattern hides all of this VPC wiring for us
-		const vpcId = new GuParameter(this, 'VpcIdParam', {
-			fromSSM: true,
-			default: `/account/vpc/primary/id`,
-			description: 'The VPC to deploy the structuriser to',
-		});
-
-		const publicSubnetIds = new GuParameter(this, 'VpcPublicParam', {
-			fromSSM: true,
-			default: '/account/vpc/primary/subnets/public',
-			type: 'List<String>',
-		});
-
-		const privateSubnetIds = new GuParameter(this, 'VpcPrivateParam', {
+		const privateSubnetIds = new GuParameter(this, 'VpcPrivateSubnetsParam', {
 			fromSSM: true,
 			default: '/account/vpc/primary/subnets/private',
 			type: 'List<String>',
 		});
 
+		// Trying to use vpcFromEc2AppPattern fails with the following error:
+		// ValidationError: There are no 'Public' subnet groups in this VPC. Available types:
 		const vpcThatEcsClusterConstructWillAccept = Vpc.fromVpcAttributes(
 			this,
 			'Vpc',
 			{
-				vpcId: vpcId.valueAsString,
-				publicSubnetIds: publicSubnetIds.valueAsList,
+				vpcId: vpcFromEc2AppPattern.vpcId,
+				// We have to provide public subnet ids to get passed a validation error, but they are unused
+				publicSubnetIds: [''],
+				// This seems to be the important bit that is missing from the IVpc that the pattern provides
 				privateSubnetIds: privateSubnetIds.valueAsList,
 				availabilityZones: [''], // The type system forces us to provide this, but it doesn't actually seem to be needed
 			},
@@ -159,8 +150,8 @@ export class CdkPlayground extends GuStack {
 
 		// AWS::ECS::Cluster
 		const cluster = new Cluster(this, 'EcsCluster', {
-			// Trying to use vpcFromEc2AppPattern fails with the following error:
-			// ValidationError: There are no 'Public' subnet groups in this VPC. Available types:
+			// We have to pass in an IVpc here, but the generated CFN only actually references the private subnets ids when
+			// setting up the ECS service.
 			vpc: vpcThatEcsClusterConstructWillAccept,
 		});
 

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -164,7 +164,8 @@ export class CdkPlayground extends GuStack {
 		// ## Potential Issues
 		// * Load balancer deletion protection is false (to match pattern this should be true)
 		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
-		// * Logging?
+		// * Logging - ships to CloudWatch by default and https://github.com/guardian/cloudwatch-logs-management can be
+		//   configured to pick up from there
 		// * Deployment?
 		//
 		// ## CFN resources

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -163,8 +163,7 @@ export class CdkPlayground extends GuStack {
 			// buildIdentifier,
 		);
 
-		// ## Potential ECS Issues
-		// * Load balancer deletion protection is false (to match pattern this should be true)
+		// ## TODO
 		// * Logging - ships to CloudWatch by default and https://github.com/guardian/cloudwatch-logs-management can be
 		//   configured to pick up from there
 		// * Deployment?

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -162,7 +162,6 @@ export class CdkPlayground extends GuStack {
 		// Potential Issues
 		// * Load balancer deletion protection is false (to match pattern this should be true)
 		// * Allows all outbound traffic by default (to match pattern this would be HTTPs only)
-		// * Target group port
 		// * ECS health check grace period - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html#sd-networkconfiguration
 		// * Target group health checks?
 		// * IAM roles / permissions?
@@ -177,6 +176,7 @@ export class CdkPlayground extends GuStack {
 				certificate,
 				taskImageOptions: {
 					image,
+					containerPort: 9000,
 				},
 			},
 		);

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -25,11 +25,6 @@ import {
 	LogDriver,
 } from 'aws-cdk-lib/aws-ecs';
 import type { CfnListener } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import {
-	ApplicationProtocol,
-	ApplicationTargetGroup,
-	TargetType,
-} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is an alternative to https://github.com/guardian/cdk-playground/pull/1035. It demonstrates how we might  use [AWS ECS _constructs_](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html) to provision the necessary infrastructure for running this application on ECS (instead of EC2). We end up with basically the same infrastructure but using constructs makes it possible to 'share' a load balancer with the existing EC2 infrastructure (rather than provisioning a new one).

This approach might be preferable to using AWS's patterns because it is consistent with our preferred migration path, which allows us to retain an application's existing ALB and switch traffic at the target group level. More details on the rationale for attempting to retain an existing ALB can be found [here](https://github.com/guardian/cdk-playground/pull/1035).

If we were to go ahead with this approach then most of the new code in [`cdk-playground.ts`](https://github.com/guardian/cdk-playground/blob/bc3b985d0dacb91a4ae9bc61ff1f8795ed514391/cdk/lib/cdk-playground.ts) would be provided to users via a GuCDK pattern (or patterns[^1]). 

## How has this change been tested?

I've [deployed this successfully](https://riffraff.gutools.co.uk/deployment/view/5ee9d08d-9d8b-4473-9c31-0c60291f62de). I've confirmed that requests to https://cdk-playground.code.dev-gutools.co.uk/ are now being served via EC2 and ECS (target group weighting is 50/50 so there is an equal chance of hitting either backend when making a request).

[^1]: I think we'd probably need a stepping stone pattern (`GuEc2AndEcsApp`) to facilitate migrations from existing users of `GuEc2App`. We'd also need a simpler ECS pattern (`GuEcsApp`), which would be the desired end state for a migration and an appropriate choice for any new applications.