### PR TITLE
ci: Publish an image to AWS ECR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,3 +48,34 @@ jobs:
               - lambda/cdk-playground-lambda.zip
             event-forwarder:
               - cdk/dist/event-forwarder.zip
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+          mask-aws-account-id: 'true'
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.1
+        with:
+          mask-password: 'true'
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }} # TODO Update https://github.com/guardian/riffraff-platform to add the ECR repository URI as a repository secret. This would allow us to login exactly before push, and no earlier.
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          ORIGINAL_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+        run: |
+          # Remove "refs/heads/" prefix from ORIGINAL_BRANCH_NAME
+          TRIMMED_BRANCH_NAME="${ORIGINAL_BRANCH_NAME#refs/heads/}"
+
+          # Replace / with - and export it to make it available to sbt
+          export BRANCH_NAME=${TRIMMED_BRANCH_NAME//\//-}
+
+          sbt Docker/publishLocal
+
+          docker push $REGISTRY/$REPOSITORY --all-tags

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val akkaSerializationJacksonOverrides = Seq(
 def env(propName: String): Option[String] = sys.env.get(propName).filter(_.trim.nonEmpty)
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin)
+  .enablePlugins(PlayScala, BuildInfoPlugin, JDebPackaging, SystemdPlugin, DockerPlugin, AshScriptPlugin)
   .settings(
     name := """cdk-playground""",
     version := "1.0-SNAPSHOT",
@@ -29,13 +29,11 @@ lazy val root = (project in file("."))
     ),
     Universal / javaOptions ++= Seq(
       s"-Dpidfile.path=/dev/null",
-      s"-J-Dlogs.home=/var/log/${packageName.value}",
-      s"-J-Xlog:gc*:file=/var/log/${packageName.value}/gc.log:time,uptime,level,tags",
     ),
 
-    libraryDependencies ++= jacksonOverrides
-      ++ akkaSerializationJacksonOverrides
-      ++ Seq(
+    libraryDependencies ++= jacksonOverrides ++
+      akkaSerializationJacksonOverrides ++
+      Seq(
         "net.logstash.logback" % "logstash-logback-encoder" % "8.1",
         // Transient dependency of Play. No newer version of Play 2.9 or Play 3.0 with this vulnerability fixed.
         "ch.qos.logback" % "logback-classic" % "1.5.32",
@@ -62,5 +60,20 @@ lazy val root = (project in file("."))
     buildInfoOptions := Seq(
       BuildInfoOption.Traits("management.BuildInfo"),
       BuildInfoOption.ToJson
-    )
+    ),
+
+    dockerBaseImage := "amazoncorretto:21-alpine",
+    dockerBuildxPlatforms := Seq("linux/amd64"),
+    dockerAliases := Seq(
+      "sha"    -> env("COMMIT_SHA").getOrElse("dev"),
+      "build"  -> env("BUILD_NUMBER").getOrElse("dev"),
+      "branch" -> env("BRANCH_NAME").getOrElse("dev")
+    ).map { case (prefix, value) =>
+      DockerAlias(
+        name = name.value,
+        registryHost = Some(s"${env("REGISTRY").getOrElse("dev")}/guardian"),
+        username = None,
+        tag = Some(s"$prefix-$value"),
+      )
+    }
   )

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -3,19 +3,8 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>${application.home:-.}/logs/application.log</file>
-    <encoder>
-      <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-    </encoder>
-  </appender>
-
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-  </appender>
-
-  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
-    <appender-ref ref="FILE" />
   </appender>
 
   <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
@@ -23,7 +12,6 @@
   </appender>
 
   <root level="INFO">
-    <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
 


### PR DESCRIPTION
## What does this change?
An alternative to https://github.com/guardian/cdk-playground/pull/1032, this change publishes the Scala Play app to AWS ECR using https://www.scala-sbt.org/sbt-native-packager/formats/docker.html.

## How has this change been tested?
```console
AWS_PROFILE=deployTools
AWS_DEFAULT_REGION=eu-west-1
ACCOUNT_ID=$(aws sts get-caller-identity | jq -r .Account)
REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
IMAGE="${REGISTRY}/guardian/cdk-playground:branch-aa-docker-image"

# Login to AWS ECR https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html
aws ecr get-login-password | docker login --username AWS --password-stdin $REGISTRY

# Pull image
docker pull $IMAGE

# Run image
docker run --platform linux/amd64 --publish 9000:9000 $IMAGE
```

With the image running, we can then visit `localhost:9000`:

```console
❯ curl --silent localhost:9000 | jq .
{
  "name": "cdk-playground",
  "buildTime": 1775663577355,
  "branch": "aa/docker-image",
  "gitCommitId": "2d6c4aa60a4abc612413a525ef5c0af5ec518d36",
  "scalaVersion": "2.13.18",
  "version": "1.0-SNAPSHOT",
  "sbtVersion": "1.12.8",
  "buildNumber": "2125"
}
```

To also confirm these changes do not negatively impact the EC2 application, I've [successfully deployed this branch](https://riffraff.gutools.co.uk/deployment/view/f9174972-6f84-4d6f-94e3-4eedc9c62f19).