### PR TITLE
Split EC2 and Lambda infrastructure into 2 separate stacks

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,16 +1,21 @@
 import 'source-map-support/register';
 import { GuRoot } from '@guardian/cdk/lib/constructs/root';
-import { CdkPlayground } from '../lib/cdk-playground';
+import { CdkPlaygroundEc2, CdkPlaygroundLambda } from '../lib/cdk-playground';
 import { EventForwarder } from '../lib/event-forwarder';
 
 const app = new GuRoot();
 
 const eventForwarder = new EventForwarder(app, 'EventForwarder-CODE');
 
-const applicationStack = new CdkPlayground(app, 'CdkPlayground-CODE', {
-	cloudFormationStackName: 'deploy-CODE-cdk-playground',
+const ec2Stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
+	cloudFormationStackName: 'deploy-CODE-cdk-playground-ec2',
+	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+});
+
+new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
+	cloudFormationStackName: 'deploy-CODE-cdk-playground-lambda',
 	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 });
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.
-applicationStack.addDependency(eventForwarder);
+ec2Stack.addDependency(eventForwarder);

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -26,38 +26,16 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "GuHttpsApplicationListener",
       "GuRiffRaffDeploymentIdParameter",
       "GuCname",
-      "GuAsgMinInstancesInServiceParameterExperimental",
     ],
     "gu:cdk:version": "TEST",
   },
   "Outputs": {
-    "AutoscalingGroupName": {
-      "Value": {
-        "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
-      },
-    },
     "LoadBalancerCdkplaygroundDnsName": {
       "Description": "DNS entry for LoadBalancerCdkplayground",
       "Value": {
         "Fn::GetAtt": [
           "LoadBalancerCdkplayground7C6B4D97",
           "DNSName",
-        ],
-      },
-    },
-    "ScaleInArn": {
-      "Value": {
-        "Fn::GetAtt": [
-          "AutoScalingGroupCdkplaygroundScaleIn24F0C6B8",
-          "Arn",
-        ],
-      },
-    },
-    "ScaleOutArn": {
-      "Value": {
-        "Fn::GetAtt": [
-          "AutoScalingGroupCdkplaygroundScaleOutA06BF2EE",
-          "Arn",
         ],
       },
     },
@@ -81,9 +59,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "MinInstancesInServiceForcdkplayground": {
-      "Type": "Number",
     },
     "RiffRaffDeploymentId": {
       "Description": "Used by Riff-Raff to inject the deployment ID.",
@@ -148,6 +123,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         "AsgRollingUpdatePolicy2A1DDC6F",
       ],
       "Properties": {
+        "DesiredCapacity": "1",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
@@ -220,9 +196,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": 10,
-          "MinInstancesInService": {
-            "Ref": "MinInstancesInServiceForcdkplayground",
-          },
+          "MinInstancesInService": 1,
           "MinSuccessfulInstancesPercent": 100,
           "PauseTime": "PT3M",
           "SuspendProcesses": [
@@ -236,28 +210,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           "WaitOnResourceSignals": true,
         },
       },
-    },
-    "AutoScalingGroupCdkplaygroundScaleIn24F0C6B8": {
-      "Properties": {
-        "AdjustmentType": "ChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
-        },
-        "PolicyType": "SimpleScaling",
-        "ScalingAdjustment": -1,
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-    },
-    "AutoScalingGroupCdkplaygroundScaleOutA06BF2EE": {
-      "Properties": {
-        "AdjustmentType": "ChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "AutoScalingGroupCdkplaygroundASGD6E49F0F",
-        },
-        "PolicyType": "SimpleScaling",
-        "ScalingAdjustment": 1,
-      },
-      "Type": "AWS::AutoScaling::ScalingPolicy",
     },
     "CertificateCdkplayground47FCF7D9": {
       "DeletionPolicy": "Retain",

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`The Deploy stack matches the snapshot for CODE 1`] = `
+exports[`The cdk-playground infrastructure definition matches the snapshot for EC2 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
@@ -25,9 +25,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuRiffRaffDeploymentIdParameter",
-      "GuCname",
-      "GuApiLambda",
-      "GuCertificate",
       "GuCname",
       "GuAsgMinInstancesInServiceParameterExperimental",
     ],
@@ -61,28 +58,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
         "Fn::GetAtt": [
           "AutoScalingGroupCdkplaygroundScaleOutA06BF2EE",
           "Arn",
-        ],
-      },
-    },
-    "lambdacdkplaygroundlambdaapiEndpoint0E1DFC5F": {
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            "https://",
-            {
-              "Ref": "lambdacdkplaygroundlambdaapi061BB942",
-            },
-            ".execute-api.eu-west-1.",
-            {
-              "Ref": "AWS::URLSuffix",
-            },
-            "/",
-            {
-              "Ref": "lambdacdkplaygroundlambdaapiDeploymentStageprod4C07895E",
-            },
-            "/",
-          ],
         ],
       },
     },
@@ -303,42 +278,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
           },
           {
             "Key": "Name",
-            "Value": "CdkPlayground-CODE/CertificateCdkplayground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "CertificateCdkplaygroundlambda82D0BE4D": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "DomainName": "cdk-playground-lambda.code.dev-gutools.co.uk",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "cdk-playground-lambda",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Name",
-            "Value": "CdkPlayground-CODE/CertificateCdkplaygroundlambda",
+            "Value": "CdkPlaygroundEc2-CODE/CertificateCdkplayground",
           },
           {
             "Key": "Stack",
@@ -469,7 +409,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "GuHttpsEgressSecurityGroupCdkplaygroundfromCdkPlaygroundCODELoadBalancerCdkplaygroundSecurityGroup0DBDF6109000EA378CBA": {
+    "GuHttpsEgressSecurityGroupCdkplaygroundfromCdkPlaygroundEc2CODELoadBalancerCdkplaygroundSecurityGroup18287D7A9000703932FA": {
       "Properties": {
         "Description": "Load balancer to target",
         "FromPort": 9000,
@@ -568,23 +508,6 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "LambdaDNS": {
-      "Properties": {
-        "Name": "cdk-playground-lambda.code.dev-gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": [
-          {
-            "Fn::GetAtt": [
-              "lambdacdkplaygroundlambdaapidomainD1A8D46F",
-              "RegionalDomainName",
-            ],
-          },
-        ],
-        "Stage": "CODE",
-        "TTL": 3600,
-      },
-      "Type": "Guardian::DNS::RecordSet",
-    },
     "ListenerCdkplaygroundA8D9CA6F": {
       "Properties": {
         "Certificates": [
@@ -681,7 +604,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
     },
     "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05": {
       "Properties": {
-        "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundCODELoadBalancerCdkplaygroundACDA30E1",
+        "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundEc2CODELoadBalancerCdkplayground1F3A3E79",
         "SecurityGroupIngress": [
           {
             "CidrIp": "0.0.0.0/0",
@@ -719,7 +642,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundCODEGuHttpsEgressSecurityGroupCdkplayground610B4DD790000DEACC63": {
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundEc2CODEGuHttpsEgressSecurityGroupCdkplayground0BB5710F9000BBED7E0F": {
       "Properties": {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": {
@@ -931,7 +854,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "CdkPlayground-CODE/deploy-CODE-cdk-playground",
+                  "Value": "CdkPlaygroundEc2-CODE/deploy-CODE-cdk-playground",
                 },
                 {
                   "Key": "Stack",
@@ -964,7 +887,7 @@ exports[`The Deploy stack matches the snapshot for CODE 1`] = `
                 },
                 {
                   "Key": "Name",
-                  "Value": "CdkPlayground-CODE/deploy-CODE-cdk-playground",
+                  "Value": "CdkPlaygroundEc2-CODE/deploy-CODE-cdk-playground",
                 },
                 {
                   "Key": "Stack",
@@ -1057,7 +980,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
               },
               {
                 "Key": "Name",
-                "Value": "CdkPlayground-CODE/deploy-CODE-cdk-playground",
+                "Value": "CdkPlaygroundEc2-CODE/deploy-CODE-cdk-playground",
               },
               {
                 "Key": "Stack",
@@ -1082,6 +1005,105 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
         ],
       },
       "Type": "AWS::IAM::InstanceProfile",
+    },
+  },
+}
+`;
+
+exports[`The cdk-playground infrastructure definition matches the snapshot for Lambda 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuApiLambda",
+      "GuCertificate",
+      "GuCname",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "lambdacdkplaygroundlambdaapiEndpoint0E1DFC5F": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "lambdacdkplaygroundlambdaapi061BB942",
+            },
+            ".execute-api.eu-west-1.",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "lambdacdkplaygroundlambdaapiDeploymentStageprod4C07895E",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "CertificateCdkplaygroundlambda82D0BE4D": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "cdk-playground-lambda.code.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Name",
+            "Value": "CdkPlaygroundLambda-CODE/CertificateCdkplaygroundlambda",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "LambdaDNS": {
+      "Properties": {
+        "Name": "cdk-playground-lambda.code.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "lambdacdkplaygroundlambdaapidomainD1A8D46F",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "Stage": "CODE",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "lambda8B5974B5": {
       "DependsOn": [
@@ -1353,7 +1375,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
       },
       "Type": "AWS::ApiGateway::Method",
     },
-    "lambdacdkplaygroundlambdaapiANYApiPermissionCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYC109836E": {
+    "lambdacdkplaygroundlambdaapiANYApiPermissionCdkPlaygroundLambdaCODElambdacdkplaygroundlambdaapi34277BEBANYC425F854": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -1390,7 +1412,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdacdkplaygroundlambdaapiANYApiPermissionTestCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYB41263D8": {
+    "lambdacdkplaygroundlambdaapiANYApiPermissionTestCdkPlaygroundLambdaCODElambdacdkplaygroundlambdaapi34277BEBANY8D210438": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -1584,7 +1606,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
       },
       "Type": "AWS::ApiGateway::DomainName",
     },
-    "lambdacdkplaygroundlambdaapidomainMapCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8E22B777C": {
+    "lambdacdkplaygroundlambdaapidomainMapCdkPlaygroundLambdaCODElambdacdkplaygroundlambdaapi34277BEB1FBC9448": {
       "Properties": {
         "DomainName": {
           "Ref": "lambdacdkplaygroundlambdaapidomainD1A8D46F",
@@ -1598,7 +1620,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
-    "lambdacdkplaygroundlambdaapiproxyANYApiPermissionCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYproxyD3A0C3C8": {
+    "lambdacdkplaygroundlambdaapiproxyANYApiPermissionCdkPlaygroundLambdaCODElambdacdkplaygroundlambdaapi34277BEBANYproxyCC311E10": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -1635,7 +1657,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "lambdacdkplaygroundlambdaapiproxyANYApiPermissionTestCdkPlaygroundCODElambdacdkplaygroundlambdaapi4F3304E8ANYproxyD0C7A195": {
+    "lambdacdkplaygroundlambdaapiproxyANYApiPermissionTestCdkPlaygroundLambdaCODElambdacdkplaygroundlambdaapi34277BEBANYproxy0AFC0599": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {

--- a/cdk/lib/cdk-playground.test.ts
+++ b/cdk/lib/cdk-playground.test.ts
@@ -1,11 +1,18 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { CdkPlayground } from './cdk-playground';
+import { CdkPlaygroundEc2, CdkPlaygroundLambda } from './cdk-playground';
 
-describe('The Deploy stack', () => {
-	it('matches the snapshot for CODE', () => {
+describe('The cdk-playground infrastructure definition', () => {
+	it('matches the snapshot for EC2', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
-		const stack = new CdkPlayground(app, 'CdkPlayground-CODE', {
+		const stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
+			buildIdentifier: 'TEST',
+		});
+		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+	});
+	it('matches the snapshot for Lambda', () => {
+		const app = new App({ outdir: '/tmp/cdk.out' });
+		const stack = new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
 			buildIdentifier: 'TEST',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -6,8 +6,7 @@ import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
-import { CfnOutput, Duration } from 'aws-cdk-lib';
-import { CfnScalingPolicy } from 'aws-cdk-lib/aws-autoscaling';
+import { Duration } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
@@ -63,35 +62,6 @@ export class CdkPlaygroundEc2 extends GuStack {
 			},
 			imageRecipe: 'arm64-jammy-java21-deploy-infrastructure',
 			instanceMetricGranularity: '5Minute',
-		});
-
-		const scaleOutPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleOut', {
-			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
-			policyType: 'SimpleScaling',
-			adjustmentType: 'ChangeInCapacity',
-			scalingAdjustment: 1,
-		});
-
-		const scaleInPolicy = new CfnScalingPolicy(autoScalingGroup, 'ScaleIn', {
-			autoScalingGroupName: autoScalingGroup.autoScalingGroupName,
-			policyType: 'SimpleScaling',
-			adjustmentType: 'ChangeInCapacity',
-			scalingAdjustment: -1,
-		});
-
-		new CfnOutput(this, 'ScaleOutArn', {
-			key: 'ScaleOutArn',
-			value: scaleOutPolicy.attrArn,
-		});
-
-		new CfnOutput(this, 'ScaleInArn', {
-			key: 'ScaleInArn',
-			value: scaleInPolicy.attrArn,
-		});
-
-		new CfnOutput(this, 'AutoscalingGroupName', {
-			key: 'AutoscalingGroupName',
-			value: autoScalingGroup.autoScalingGroupName,
 		});
 
 		new GuCname(this, 'EC2AppDNS', {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -22,7 +22,7 @@ interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	buildIdentifier: string;
 }
 
-export class CdkPlayground extends GuStack {
+export class CdkPlaygroundEc2 extends GuStack {
 	constructor(scope: App, id: string, props: CdkPlaygroundProps) {
 		super(scope, id, {
 			...props,
@@ -34,11 +34,10 @@ export class CdkPlayground extends GuStack {
 		const { buildIdentifier } = props;
 
 		const ec2AppDomainName = 'cdk-playground.code.dev-gutools.co.uk';
-		const lambdaDomainName = 'cdk-playground-lambda.code.dev-gutools.co.uk';
 
 		const ec2App = 'cdk-playground';
 
-		const { loadBalancer, autoScalingGroup } = new GuEc2AppExperimental(this, {
+		const { loadBalancer } = new GuEc2AppExperimental(this, {
 			buildIdentifier,
 			applicationPort: 9000,
 			app: ec2App,
@@ -101,7 +100,19 @@ export class CdkPlayground extends GuStack {
 			domainName: ec2AppDomainName,
 			resourceRecord: loadBalancer.loadBalancerDnsName,
 		});
+	}
+}
 
+export class CdkPlaygroundLambda extends GuStack {
+	constructor(scope: App, id: string, props: CdkPlaygroundProps) {
+		super(scope, id, {
+			...props,
+			stack: 'deploy',
+			stage: 'CODE',
+			env: { region: 'eu-west-1' },
+		});
+
+		const lambdaDomainName = 'cdk-playground-lambda.code.dev-gutools.co.uk';
 		const lambdaApp = 'cdk-playground-lambda';
 
 		const lambda = new GuApiLambda(this, 'lambda', {


### PR DESCRIPTION
## What does this change?

I've recently been working on adding some ECS infrastructure and I'm finding that having all of the different patterns defined in a single CloudFormation stack is making testing more complex. Consequently, this PR splits the EC2 infrastructure and the Lambda infrastructure into separate CloudFormation stacks. 

Once this PR is merged I will introduce a dedicated ECS stack to use for deployment testing.

Some other notes:
* I've removed the scaling stuff from the EC2 infrastructure because this also increases complexity[^1] and we're not currently doing any testing in this area.
* I've left the `event-forwarder` stuff (introduced in https://github.com/guardian/cdk-playground/pull/533) alone for now, but I think we could probably drop that too in a follow-up PR?
* We could push this further and deploy each architecture pattern via a separate Riff-Raff project, but using the `Preview` feature to only deploy the CloudFormation stack that I'm interested in will be fine for now.

## How has this change been tested?

I've torn down the old stack and [deployed this to `CODE`](https://riffraff.gutools.co.uk/deployment/view/f274dc95-93a8-41da-aba5-a26167880acf). The new stacks were created as expected:

<img width="1533" height="373" alt="image" src="https://github.com/user-attachments/assets/6647d1b7-b60a-410b-88e0-7630043126e5" />

## How can we measure success?

This should make it easier to test changes in this repository going forwards. In the first instance, it will allow us to run testing related to ECS deployments without interference from the EC2 deployment mechanism[^2].

## Have we considered potential risks?

I don't think there are any risks here; we just use this project for testing.

[^1]: For example, we can't currently re-provision the EC2 infrastructure from scratch if we're using the new deployment mechanism _and_ scaling policies.
[^2]: Currently when an EC2 deployment fails it fails the whole CloudFormation update. This also stops/rolls back the ECS deployment.