### PR TITLE
Add first pass at an ECS stack

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,6 +1,10 @@
 import 'source-map-support/register';
 import { GuRoot } from '@guardian/cdk/lib/constructs/root';
-import { CdkPlaygroundEc2, CdkPlaygroundLambda } from '../lib/cdk-playground';
+import {
+	CdkPlaygroundEc2,
+	CdkPlaygroundEcs,
+	CdkPlaygroundLambda,
+} from '../lib/cdk-playground';
 import { EventForwarder } from '../lib/event-forwarder';
 
 const app = new GuRoot();
@@ -14,6 +18,11 @@ const ec2Stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
 
 new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-lambda',
+	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+});
+
+new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
+	cloudFormationStackName: 'deploy-CODE-cdk-playground-ecs',
 	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 });
 

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -965,8 +965,801 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
 exports[`The cdk-playground infrastructure definition matches the snapshot for ECS 1`] = `
 {
   "Metadata": {
-    "gu:cdk:constructs": [],
+    "gu:cdk:constructs": [
+      "GuVpcParameter",
+      "GuParameter",
+      "GuParameterStoreReadPolicy",
+      "GuHttpsEgressSecurityGroup",
+      "GuSubnetListParameter",
+      "GuApplicationLoadBalancer",
+      "GuAccessLoggingBucketParameter",
+      "GuApplicationTargetGroup",
+      "GuCertificate",
+      "GuHttpsApplicationListener",
+      "GuCname",
+    ],
     "gu:cdk:version": "TEST",
+  },
+  "Outputs": {
+    "LoadBalancerCdkplaygroundecsDnsName": {
+      "Description": "DNS entry for LoadBalancerCdkplaygroundecs",
+      "Value": {
+        "Fn::GetAtt": [
+          "LoadBalancerCdkplaygroundecsA22B17EA",
+          "DNSName",
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "AccessLoggingBucket": {
+      "Default": "/account/services/access-logging/bucket",
+      "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "VpcId": {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "VpcPrivateSubnetsParam": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
+    },
+    "cdkplaygroundecsPublicSubnets": {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+  },
+  "Resources": {
+    "CertificateCdkplaygroundecsD6C69B43": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "cdk-playground-ecs.code.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Name",
+            "Value": "CdkPlaygroundEcs-CODE/CertificateCdkplaygroundecs",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "EcsCluster97242B84": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "EcsDns": {
+      "Properties": {
+        "Name": "cdk-playground-ecs.code.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerCdkplaygroundecsA22B17EA",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "CODE",
+        "TTL": 60,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "EcsService81FC6EF6": {
+      "DependsOn": [
+        "EcsTaskDefinitionTaskRoleB7B6D8DD",
+        "ListenerCdkplaygroundecs3194EDCD",
+      ],
+      "Properties": {
+        "Cluster": {
+          "Ref": "EcsCluster97242B84",
+        },
+        "DeploymentConfiguration": {
+          "Alarms": {
+            "AlarmNames": [],
+            "Enable": false,
+            "Rollback": false,
+          },
+          "DeploymentCircuitBreaker": {
+            "Enable": true,
+            "Rollback": true,
+          },
+          "MaximumPercent": 200,
+          "MinimumHealthyPercent": 100,
+        },
+        "DeploymentController": {
+          "Type": "ECS",
+        },
+        "EnableECSManagedTags": false,
+        "HealthCheckGracePeriodSeconds": 60,
+        "LaunchType": "FARGATE",
+        "LoadBalancers": [
+          {
+            "ContainerName": "cdk-playground",
+            "ContainerPort": 9000,
+            "TargetGroupArn": {
+              "Ref": "EcsTargetGroupCdkplaygroundecsF5A8D17A",
+            },
+          },
+        ],
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": [
+              {
+                "Fn::GetAtt": [
+                  "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
+                  "GroupId",
+                ],
+              },
+            ],
+            "Subnets": {
+              "Ref": "VpcPrivateSubnetsParam",
+            },
+          },
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TaskDefinition": {
+          "Ref": "EcsTaskDefinition63157ED3",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "EcsServiceTaskCountTarget02FCCE22": {
+      "DependsOn": [
+        "EcsTaskDefinitionTaskRoleB7B6D8DD",
+      ],
+      "Properties": {
+        "MaxCapacity": 6,
+        "MinCapacity": 3,
+        "ResourceId": {
+          "Fn::Join": [
+            "",
+            [
+              "service/",
+              {
+                "Ref": "EcsCluster97242B84",
+              },
+              "/",
+              {
+                "Fn::GetAtt": [
+                  "EcsService81FC6EF6",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+        "RoleARN": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":iam::",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService",
+            ],
+          ],
+        },
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "EcsTargetGroupCdkplaygroundecsF5A8D17A": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Name": "cdk-playground-ecs",
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "EcsTaskDefinition63157ED3": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.eu-west-1.",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/guardian/cdk-playground:build-TEST",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754",
+                },
+                "awslogs-region": "eu-west-1",
+                "awslogs-stream-prefix": "cdk-playground-ecs",
+              },
+            },
+            "Name": "cdk-playground",
+            "PortMappings": [
+              {
+                "ContainerPort": 9000,
+                "Protocol": "tcp",
+              },
+            ],
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "EcsTaskDefinitionExecutionRoleBE450C73",
+            "Arn",
+          ],
+        },
+        "Family": "CdkPlaygroundEcsCODEEcsTaskDefinitionF3F230E3",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "EcsTaskDefinitionTaskRoleB7B6D8DD",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "EcsTaskDefinitionExecutionRoleBE450C73": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EcsTaskDefinitionExecutionRoleDefaultPolicy1611A942": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecr:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":repository/guardian/cdk-playground",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EcsTaskDefinitionExecutionRoleDefaultPolicy1611A942",
+        "Roles": [
+          {
+            "Ref": "EcsTaskDefinitionExecutionRoleBE450C73",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "EcsTaskDefinitionTaskRoleB7B6D8DD": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupCdkplaygroundecsfromCdkPlaygroundEcsCODELoadBalancerCdkplaygroundecsSecurityGroup010B2D269000BEBFE3E3": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundecsSecurityGroupE3A6820F",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "ListenerCdkplaygroundecs3194EDCD": {
+      "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificateCdkplaygroundecsD6C69B43",
+            },
+          },
+        ],
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "EcsTargetGroupCdkplaygroundecsF5A8D17A",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": {
+          "Ref": "LoadBalancerCdkplaygroundecsA22B17EA",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "LoadBalancerCdkplaygroundecsA22B17EA": {
+      "Properties": {
+        "LoadBalancerAttributes": [
+          {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "routing.http.drop_invalid_header_fields.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "access_logs.s3.bucket",
+            "Value": {
+              "Ref": "AccessLoggingBucket",
+            },
+          },
+          {
+            "Key": "access_logs.s3.prefix",
+            "Value": "application-load-balancer/CODE/deploy/cdk-playground-ecs",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerCdkplaygroundecsSecurityGroupE3A6820F",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": {
+          "Ref": "cdkplaygroundecsPublicSubnets",
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerCdkplaygroundecsSecurityGroupE3A6820F": {
+      "Properties": {
+        "GroupDescription": "Automatically created Security Group for ELB CdkPlaygroundEcsCODELoadBalancerCdkplaygroundecs9FB94A74",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerCdkplaygroundecsSecurityGrouptoCdkPlaygroundEcsCODEGuHttpsEgressSecurityGroupCdkplaygroundecsD24FE46B9000417ADD3A": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundecsSecurityGroupE3A6820F",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "ParameterStoreReadCdkplaygroundecsB1E187C6": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-ecs",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-ecs/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
   },
 }
 `;

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -962,6 +962,15 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
 }
 `;
 
+exports[`The cdk-playground infrastructure definition matches the snapshot for ECS 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [],
+    "gu:cdk:version": "TEST",
+  },
+}
+`;
+
 exports[`The cdk-playground infrastructure definition matches the snapshot for Lambda 1`] = `
 {
   "Metadata": {

--- a/cdk/lib/cdk-playground.test.ts
+++ b/cdk/lib/cdk-playground.test.ts
@@ -1,6 +1,10 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { CdkPlaygroundEc2, CdkPlaygroundLambda } from './cdk-playground';
+import {
+	CdkPlaygroundEc2,
+	CdkPlaygroundEcs,
+	CdkPlaygroundLambda,
+} from './cdk-playground';
 
 describe('The cdk-playground infrastructure definition', () => {
 	it('matches the snapshot for EC2', () => {
@@ -13,6 +17,13 @@ describe('The cdk-playground infrastructure definition', () => {
 	it('matches the snapshot for Lambda', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
+			buildIdentifier: 'TEST',
+		});
+		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+	});
+	it('matches the snapshot for ECS', () => {
+		const app = new App({ outdir: '/tmp/cdk.out' });
+		const stack = new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 			buildIdentifier: 'TEST',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -2,12 +2,37 @@ import { GuApiLambda } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuParameter } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import {
+	GuHttpsEgressSecurityGroup,
+	GuVpc,
+	SubnetType,
+} from '@guardian/cdk/lib/constructs/ec2';
+import { GuParameterStoreReadPolicy } from '@guardian/cdk/lib/constructs/iam';
+import {
+	GuApplicationLoadBalancer,
+	GuApplicationTargetGroup,
+	GuHttpsApplicationListener,
+} from '@guardian/cdk/lib/constructs/loadbalancing';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
-import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import {
+	InstanceClass,
+	InstanceSize,
+	InstanceType,
+	Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+import { Repository } from 'aws-cdk-lib/aws-ecr';
+import {
+	Cluster,
+	ContainerImage,
+	FargateService,
+	FargateTaskDefinition,
+	LogDriver,
+} from 'aws-cdk-lib/aws-ecs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
 interface CdkPlaygroundProps extends Omit<GuStackProps, 'stack' | 'stage'> {
@@ -116,6 +141,8 @@ export class CdkPlaygroundLambda extends GuStack {
 	}
 }
 
+// For now, we provision all of this infrastructure via constructs as part of this repo.
+// Once we've figured out the details we'd aim to provide this to users via a GuCDK pattern instead.
 export class CdkPlaygroundEcs extends GuStack {
 	constructor(scope: App, id: string, props: CdkPlaygroundProps) {
 		super(scope, id, {
@@ -123,6 +150,139 @@ export class CdkPlaygroundEcs extends GuStack {
 			stack: 'deploy',
 			stage: 'CODE',
 			env: { region: 'eu-west-1' },
+		});
+
+		const { buildIdentifier } = props;
+		const ecsApp = 'cdk-playground-ecs';
+		const ecsDomainName = 'cdk-playground-ecs.code.dev-gutools.co.uk';
+
+		const vpc = GuVpc.fromIdParameter(this, 'GuVpc');
+
+		// Trying to use a GuVpc with the ECS Cluster construct fails with the following error:
+		// ValidationError: There are no 'Public' subnet groups in this VPC. Available types:
+
+		// We should fix this properly when introducing the ECS pattern in GuCDK
+		const vpcThatEcsClusterConstructWillAccept = Vpc.fromVpcAttributes(
+			this,
+			'Vpc',
+			{
+				vpcId: vpc.vpcId,
+				// We have to provide public subnet ids to avoid a validation error, but they are unused
+				publicSubnetIds: [''],
+				// This seems to be the important bit that is missing from the IVpc that the pattern provides
+				privateSubnetIds: new GuParameter(this, 'VpcPrivateSubnetsParam', {
+					fromSSM: true,
+					default: '/account/vpc/primary/subnets/private',
+					type: 'List<String>',
+				}).valueAsList,
+				availabilityZones: [''], // The type system forces us to provide this, but it doesn't actually seem to be needed
+			},
+		);
+
+		// AWS::ECS::Cluster
+		const cluster = new Cluster(this, 'EcsCluster', {
+			// We have to pass in an IVpc here, but the generated CFN only actually references the private subnets ids when
+			// setting up the ECS service.
+			vpc: vpcThatEcsClusterConstructWillAccept,
+		});
+
+		// Need to figure out how to make this cross-account, but this is fine for the simple case where the app and the
+		// ECR repo are both in the Deploy Tools accoutn
+		const image = ContainerImage.fromEcrRepository(
+			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
+			`build-${buildIdentifier}`,
+		);
+
+		// AWS::ECS::TaskDefinition
+		// AWS::IAM::Role ('execution role' - used for pulling image etc.)
+		// AWS::IAM::Role ('task role' - used for application's runtime permissions e.g. reading config from SSM)
+		const taskDefinition = new FargateTaskDefinition(this, 'EcsTaskDefinition');
+
+		taskDefinition.addContainer('cdk-playground', {
+			image,
+			portMappings: [{ containerPort: 9000 }],
+			// AWS::Logs::LogGroup
+			logging: LogDriver.awsLogs({
+				streamPrefix: 'cdk-playground-ecs',
+			}),
+			// Memory and cpu values can be defined here if needed
+		});
+
+		// Here's an example of providing custom IAM permissions to the task role. cdk-playground doesn't actually need any
+		// but our pattern should provide some useful defaults, such as reading from parameter store
+		new GuParameterStoreReadPolicy(this, { app: ecsApp }).attachToRole(
+			taskDefinition.taskRole,
+		);
+
+		// AWS::ECS::Service
+		const ecsService = new FargateService(this, 'EcsService', {
+			cluster,
+			taskDefinition,
+			// Important for service deployments; with the AWS defaults the service can be scaled down when deploying
+			minHealthyPercent: 100,
+			// Also important for service deployments; with the AWS defaults we don't get a fast failure when deploying a 'bad' build
+			circuitBreaker: { enable: true, rollback: true }, // This is
+			// By default, AWS will create a new security group which allows all outbound traffic
+			// We don't want this so explicitly allow outbound HTTPS only
+			// This is what we do for the current GuEc2App pattern:
+			// https://github.com/guardian/cdk/blob/3b5688637024642055ed0bf576f668e56e40830d/src/constructs/autoscaling/asg.ts#L143-L145
+			securityGroups: [
+				GuHttpsEgressSecurityGroup.forVpc(this, {
+					app: ecsApp,
+					vpc,
+				}),
+			],
+		});
+
+		// Can also set 'desiredCount' via the Fargate Service, but apparently this can lead to accidental scale downs
+		// (this seems roughly equivalent to setting min/max, rather than desired at the ASG level).
+		ecsService.autoScaleTaskCount({
+			minCapacity: 3,
+			maxCapacity: 6,
+		});
+
+		// Create a dedicated load balancer for now, but we could share a load balancer with the EC2 infrastructure for migrations
+		const loadBalancer = new GuApplicationLoadBalancer(this, 'LoadBalancer', {
+			app: ecsApp,
+			vpc,
+			internetFacing: true,
+			vpcSubnets: {
+				subnets: GuVpc.subnetsFromParameter(this, {
+					type: SubnetType.PUBLIC,
+					app: ecsApp,
+				}),
+			},
+			withAccessLogging: true,
+		});
+
+		// We need a new target group even if we share the other load balancer components with the EC2 infrastructure
+		const targetGroup = new GuApplicationTargetGroup(this, 'EcsTargetGroup', {
+			vpc,
+			app: ecsApp,
+			port: 9000,
+			targetGroupName: ecsApp, // Add the name here to make it more easily identifiable in the console etc.
+			targets: [ecsService],
+		});
+
+		// We create a dedicated listener, but we could also share a listener with the EC2 infrastructure for migrations
+		new GuHttpsApplicationListener(this, 'Listener', {
+			app: ecsApp,
+			loadBalancer,
+			certificate: new GuCertificate(this, {
+				app: ecsApp,
+				domainName: ecsDomainName,
+			}),
+			targetGroup,
+			// When open=true, AWS will create a security group which allows all inbound traffic over HTTPS
+			open: true,
+		});
+
+		// This would not be part of the new GuCDK pattern
+		new GuCname(this, 'EcsDns', {
+			app: ecsApp,
+			ttl: Duration.minutes(1),
+			domainName: ecsDomainName,
+			resourceRecord: loadBalancer.loadBalancerDnsName,
 		});
 	}
 }

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -115,3 +115,14 @@ export class CdkPlaygroundLambda extends GuStack {
 		});
 	}
 }
+
+export class CdkPlaygroundEcs extends GuStack {
+	constructor(scope: App, id: string, props: CdkPlaygroundProps) {
+		super(scope, id, {
+			...props,
+			stack: 'deploy',
+			stage: 'CODE',
+			env: { region: 'eu-west-1' },
+		});
+	}
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a new CloudFormation stack which provisions the infrastructure needed to run this test application on ECS.

The PR uses [AWS ECS _constructs_](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html) (as opposed to [AWS ECS _patterns_](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs_patterns-readme.html)) as the starting point for this new pattern. Although this is a little more verbose, it allows us to more easily share a load balancer with existing infrastructure patterns in the future, if desired.

I think it's very likely that we'll want to support this migration path, as it allows us to migrate a percentage of traffic over from EC2 to ECS at the target group level. This means that we'll be able to test the new infrastructure in a much more careful and controlled way than when migrating at the DNS level (which is what we'd have to do if we introduced a new load balancer).

This PR builds upon some previous drafts that I used for figuring out the best approach to this work:
https://github.com/guardian/cdk-playground/pull/1035
https://github.com/guardian/cdk-playground/pull/1043
https://github.com/guardian/cdk-playground/pull/1054

## How has this change been tested?

I've [deployed this to `CODE`](https://riffraff.gutools.co.uk/deployment/view/bbabdb50-17e6-4d98-9760-1c35a049fb74) and it works as expected: https://cdk-playground-ecs.code.dev-gutools.co.uk/.

## How can we measure success?

This gives us a starting point for future research tasks related to ECS, such as figuring out how deployments will work.

We can now deploy ECS infrastructure only (i.e. not EC2 and Lambda) using Riff-Raff's preview feature:

<img width="1920" height="769" alt="image" src="https://github.com/user-attachments/assets/4d0bfcd0-e103-4b43-b7e3-7ec08eb2d541" />

## Have we considered potential risks?

I don't think there are any particular risks; we just use this project for testing purposes.