### PR TITLE
Give tasks more cpu and memory

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -1300,7 +1300,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             ],
           },
         ],
-        "Cpu": "256",
+        "Cpu": "1024",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "EcsTaskDefinitionExecutionRoleBE450C73",
@@ -1308,7 +1308,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           ],
         },
         "Family": "CdkPlaygroundEcsCODEEcsTaskDefinitionF3F230E3",
-        "Memory": "512",
+        "Memory": "2048",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -196,7 +196,11 @@ export class CdkPlaygroundEcs extends GuStack {
 		// AWS::ECS::TaskDefinition
 		// AWS::IAM::Role ('execution role' - used for pulling image etc.)
 		// AWS::IAM::Role ('task role' - used for application's runtime permissions e.g. reading config from SSM)
-		const taskDefinition = new FargateTaskDefinition(this, 'EcsTaskDefinition');
+		const taskDefinition = new FargateTaskDefinition(
+			this,
+			'EcsTaskDefinition',
+			{ memoryLimitMiB: 2048, cpu: 1024 },
+		);
 
 		taskDefinition.addContainer('cdk-playground', {
 			image,
@@ -205,7 +209,6 @@ export class CdkPlaygroundEcs extends GuStack {
 			logging: LogDriver.awsLogs({
 				streamPrefix: 'cdk-playground-ecs',
 			}),
-			// Memory and cpu values can be defined here if needed
 		});
 
 		// Here's an example of providing custom IAM permissions to the task role. cdk-playground doesn't actually need any

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -199,6 +199,9 @@ export class CdkPlaygroundEcs extends GuStack {
 		const taskDefinition = new FargateTaskDefinition(
 			this,
 			'EcsTaskDefinition',
+			// The defaults from AWS CDK are extremely low so it probably makes sense for us to encode something different
+			// via our pattern - we already do this for Lambda:
+			// https://github.com/guardian/cdk/blob/b567f1219dab416680a68981a488bbbf3564fe2d/src/constructs/lambda/lambda.ts#L65-L76
 			{ memoryLimitMiB: 2048, cpu: 1024 },
 		);
 


### PR DESCRIPTION
With the (very low!) AWS CDK defaults we are hitting 100% CPU usage when tasks are launched. This means that we sometimes fail to launch new tasks, which causes problems with deployments.

<img width="1659" height="526" alt="image" src="https://github.com/user-attachments/assets/15a98fb7-d22d-40f4-ab3b-762eea6bb8c9" />

The spikes yesterday afternoon correlate with test deployments using the default memory / CPU values. The smaller spikes this morning correlate with test deployments using the new amounts allocated via this branch.

Note that when running on Fargate there are [certain restrictions on the memory / CPU combinations that you can ask for](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size):

<img width="723" height="508" alt="image" src="https://github.com/user-attachments/assets/7aa9eddc-0948-4d85-8720-457ac7aab50e" />