### PR TITLE
Update Dependabot schedule interval to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/cdk'
     schedule:
-      interval: 'weekly'
+      interval: 'quarterly'
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.
@@ -17,6 +17,6 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'quarterly'
     commit-message:
       prefix: "chore(deps): "


### PR DESCRIPTION
## What does this change?

Updates the Dependabot schedule interval from the current value to `quarterly`, so dependency update PRs are raised on the first day of each quarter (January, April, July, October).

