### PR TITLE
Disable version consistency to speed up deployments

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -1298,6 +1298,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                 "Protocol": "tcp",
               },
             ],
+            "VersionConsistency": "disabled",
           },
         ],
         "Cpu": "1024",

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -2,8 +2,7 @@ import { GuApiLambda } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuParameter } from '@guardian/cdk/lib/constructs/core';
-import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import {
 	GuHttpsEgressSecurityGroup,
@@ -32,6 +31,7 @@ import {
 	FargateService,
 	FargateTaskDefinition,
 	LogDriver,
+	VersionConsistency,
 } from 'aws-cdk-lib/aws-ecs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 
@@ -207,6 +207,9 @@ export class CdkPlaygroundEcs extends GuStack {
 
 		taskDefinition.addContainer('cdk-playground', {
 			image,
+			// This speeds up deployment, but we should probably only use it in conjunction with immutable tags
+			// https://aws.amazon.com/blogs/containers/announcing-software-version-consistency-for-amazon-ecs-services/
+			versionConsistency: VersionConsistency.DISABLED,
 			portMappings: [{ containerPort: 9000 }],
 			// AWS::Logs::LogGroup
 			logging: LogDriver.awsLogs({
@@ -227,7 +230,7 @@ export class CdkPlaygroundEcs extends GuStack {
 			// Important for service deployments; with the AWS defaults the service can be scaled down when deploying
 			minHealthyPercent: 100,
 			// Also important for service deployments; with the AWS defaults we don't get a fast failure when deploying a 'bad' build
-			circuitBreaker: { enable: true, rollback: true }, // This is
+			circuitBreaker: { enable: true, rollback: true },
 			// By default, AWS will create a new security group which allows all outbound traffic
 			// We don't want this so explicitly allow outbound HTTPS only
 			// This is what we do for the current GuEc2App pattern:


### PR DESCRIPTION
## What does this change?

By default, AWS enables a feature called [version consistency for ECS services](https://aws.amazon.com/blogs/containers/announcing-software-version-consistency-for-amazon-ecs-services/). This improves reliability and security[^1] by ensuring that all tasks running as part of a service are using an identical image. Unfortunately, it also slows down deployments significantly because it causes ECS to launch new tasks in separate 2 batches, rather than launching all new tasks as quickly as possible. Disabling this feature for this application should reduce deployment time by 30-50 seconds.

My understanding is that the same reliability and security benefits can also be achieved by using immutable tags, so I think we should finalise the immutable tag setup (there is some initial work towards this in https://github.com/guardian/riffraff-platform/pull/718) and then merge this PR to improve deployment times.

## How has this change been tested?

I've run a few deployments which include this change (i.e. I've pushed several images based on the same commit[^2]) and can see that AWS is now launching all new tasks in a single batch. 

Deployment times on ECS seem to fluctuate quite a bit. This makes it hard to properly evaluate changes like this without a more sophisticated test setup.

However, prior to this PR most ECS deployments took somewhere between 2 and 3 minutes and with this change 3/5 of the ECS deployments that I tested came in under 2-minutes.

## How can we measure success?

Deployment times should be faster on average.

## Have we considered potential risks?

Yes, I don't think we should merge this until we've figured out immutable tags properly.

[^1]: In cases where mutable tags are used.
[^2]: Whilst working on this I noticed that our `sha-` tags **do not** seem to be immutable, so we need to revisit that!