### PR TITLE
test: https://github.com/guardian/cdk/pull/2897

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@aws-sdk/client-auto-scaling": "3.1034.0",
 				"@aws-sdk/credential-providers": "3.1034.0",
-				"@guardian/cdk": "63.2.0",
+				"@guardian/cdk": "github:guardian/cdk#aa/riff-raff-yaml-comment",
 				"@guardian/eslint-config": "14.0.1",
 				"@guardian/prettier": "10.0.0",
 				"@types/aws-lambda": "8.10.161",
@@ -76,20 +76,16 @@
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
 			"version": "1.4.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
 			"version": "7.7.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -326,52 +322,52 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ec2": {
-			"version": "3.1004.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1004.0.tgz",
-			"integrity": "sha512-tfNLeHKJPz+NYczwobS9IZbIbu+75ktJFRoYaNiYrk6RLLHfHIJ/pnP9uyJqAdNt3Kh7Jslw+540ZroN41IcRg==",
+			"version": "3.1037.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1037.0.tgz",
+			"integrity": "sha512-1Vs+ej6D/WMRrxN7aYmBDmW+ysoJ1OWoHSqlSexaspRdwjVsEwPzw1odecoHDrovuLNcjK5bTq9CEaFU9R0c1w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.18",
-				"@aws-sdk/credential-provider-node": "^3.972.18",
-				"@aws-sdk/middleware-host-header": "^3.972.7",
-				"@aws-sdk/middleware-logger": "^3.972.7",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.7",
-				"@aws-sdk/middleware-sdk-ec2": "^3.972.13",
-				"@aws-sdk/middleware-user-agent": "^3.972.19",
-				"@aws-sdk/region-config-resolver": "^3.972.7",
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-endpoints": "^3.996.4",
-				"@aws-sdk/util-user-agent-browser": "^3.972.7",
-				"@aws-sdk/util-user-agent-node": "^3.973.4",
-				"@smithy/config-resolver": "^4.4.10",
-				"@smithy/core": "^3.23.8",
-				"@smithy/fetch-http-handler": "^5.3.13",
-				"@smithy/hash-node": "^4.2.11",
-				"@smithy/invalid-dependency": "^4.2.11",
-				"@smithy/middleware-content-length": "^4.2.11",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/middleware-retry": "^4.4.39",
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/middleware-stack": "^4.2.11",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/node-http-handler": "^4.4.14",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
+				"@aws-sdk/core": "^3.974.5",
+				"@aws-sdk/credential-provider-node": "^3.972.36",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-sdk-ec2": "^3.972.22",
+				"@aws-sdk/middleware-user-agent": "^3.972.35",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.21",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.17",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.5",
+				"@smithy/middleware-serde": "^4.2.20",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-body-length-browser": "^4.2.2",
 				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.38",
-				"@smithy/util-defaults-mode-node": "^4.2.41",
-				"@smithy/util-endpoints": "^3.3.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-retry": "^4.2.11",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.4",
 				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.2.11",
+				"@smithy/util-waiter": "^4.2.16",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -379,51 +375,51 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ssm": {
-			"version": "3.1004.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1004.0.tgz",
-			"integrity": "sha512-M0vxsZ8X2LFPNWgCS7XekM/8SUPOEnSWaMDXLoXmO/BxW8M3wV84ijXQx0x+8EcR+945ZOOWFD+9rpmGd3RX3A==",
+			"version": "3.1037.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1037.0.tgz",
+			"integrity": "sha512-bpOon1QQ+FN1yH7NbjjHnyQ7y5xPvS/3vS2nL3+e2+Iu9sA+WJwgwquk6N+U1EtnAuGPAl9eNzk0GnEHaIwAOQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.18",
-				"@aws-sdk/credential-provider-node": "^3.972.18",
-				"@aws-sdk/middleware-host-header": "^3.972.7",
-				"@aws-sdk/middleware-logger": "^3.972.7",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.7",
-				"@aws-sdk/middleware-user-agent": "^3.972.19",
-				"@aws-sdk/region-config-resolver": "^3.972.7",
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-endpoints": "^3.996.4",
-				"@aws-sdk/util-user-agent-browser": "^3.972.7",
-				"@aws-sdk/util-user-agent-node": "^3.973.4",
-				"@smithy/config-resolver": "^4.4.10",
-				"@smithy/core": "^3.23.8",
-				"@smithy/fetch-http-handler": "^5.3.13",
-				"@smithy/hash-node": "^4.2.11",
-				"@smithy/invalid-dependency": "^4.2.11",
-				"@smithy/middleware-content-length": "^4.2.11",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/middleware-retry": "^4.4.39",
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/middleware-stack": "^4.2.11",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/node-http-handler": "^4.4.14",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
+				"@aws-sdk/core": "^3.974.5",
+				"@aws-sdk/credential-provider-node": "^3.972.36",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-user-agent": "^3.972.35",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.21",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.17",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.5",
+				"@smithy/middleware-serde": "^4.2.20",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-body-length-browser": "^4.2.2",
 				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.38",
-				"@smithy/util-defaults-mode-node": "^4.2.41",
-				"@smithy/util-endpoints": "^3.3.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-retry": "^4.2.11",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.4",
 				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.2.11",
+				"@smithy/util-waiter": "^4.2.16",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -431,24 +427,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.3.tgz",
-			"integrity": "sha512-W3aJJm2clu8OmsrwMOMnfof13O6LGnbknnZIQeSRbxjqKah2nVvkjbUBBZVhWrt08KC69H7WsINTdrxC/2SXQw==",
+			"version": "3.974.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+			"integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.18",
-				"@smithy/core": "^3.23.16",
+				"@aws-sdk/xml-builder": "^3.972.19",
+				"@smithy/core": "^3.23.17",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-retry": "^4.3.4",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -474,13 +470,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.29.tgz",
-			"integrity": "sha512-rf+AlUxgTeSzQ/4zoS0D+Bt7XvgpY48PnWG8Yg/N9fdMgyK2Jaqa+6tLZp4MYMIMHkGrfAxnbSeb2YLMGFMg6g==",
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+			"integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.5",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/types": "^4.14.1",
@@ -491,21 +487,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.31.tgz",
-			"integrity": "sha512-TR2/lQ3qKFj2EOrsiASzemsNEz2uzZ/SUBf48+U4Cr9a/FZlHfH/hwAeBJNBp1gMyJNxROJZhT3dn1cO+jnYfQ==",
+			"version": "3.972.33",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+			"integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.5",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/node-http-handler": "^4.6.1",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-stream": "^4.5.25",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -513,20 +509,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.33.tgz",
-			"integrity": "sha512-UwdbJbOrgnOxZbshaNZ4DzX35h5wQd33MNYTGzWhN3ORG9lG9KQbDX6l6tDJSAdaGTktJoZPSritmUoW1rYkRA==",
+			"version": "3.972.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+			"integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/credential-provider-env": "^3.972.29",
-				"@aws-sdk/credential-provider-http": "^3.972.31",
-				"@aws-sdk/credential-provider-login": "^3.972.33",
-				"@aws-sdk/credential-provider-process": "^3.972.29",
-				"@aws-sdk/credential-provider-sso": "^3.972.33",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.5",
+				"@aws-sdk/credential-provider-env": "^3.972.31",
+				"@aws-sdk/credential-provider-http": "^3.972.33",
+				"@aws-sdk/credential-provider-login": "^3.972.35",
+				"@aws-sdk/credential-provider-process": "^3.972.31",
+				"@aws-sdk/credential-provider-sso": "^3.972.35",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.35",
+				"@aws-sdk/nested-clients": "^3.997.3",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/credential-provider-imds": "^4.2.14",
 				"@smithy/property-provider": "^4.2.14",
@@ -539,14 +535,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.33.tgz",
-			"integrity": "sha512-WyZuPVoDM1HGNl41eVg8HSSXIB+FGkuuK63GhDbh4TMdfWU03AciWvF/QqOVWvJtWVYaLddANJ+aUklVr2ieuw==",
+			"version": "3.972.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+			"integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.5",
+				"@aws-sdk/nested-clients": "^3.997.3",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
@@ -559,18 +555,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.34.tgz",
-			"integrity": "sha512-sPcisURibKU4x0PCWJkWF1KJYm49Cph9dCn/PAnG5FU0wq5Id3g2v7RuEWAtNlKv1Af4gUJYBVGOeNpSEEx41A==",
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+			"integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.29",
-				"@aws-sdk/credential-provider-http": "^3.972.31",
-				"@aws-sdk/credential-provider-ini": "^3.972.33",
-				"@aws-sdk/credential-provider-process": "^3.972.29",
-				"@aws-sdk/credential-provider-sso": "^3.972.33",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
+				"@aws-sdk/credential-provider-env": "^3.972.31",
+				"@aws-sdk/credential-provider-http": "^3.972.33",
+				"@aws-sdk/credential-provider-ini": "^3.972.35",
+				"@aws-sdk/credential-provider-process": "^3.972.31",
+				"@aws-sdk/credential-provider-sso": "^3.972.35",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.35",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/credential-provider-imds": "^4.2.14",
 				"@smithy/property-provider": "^4.2.14",
@@ -583,13 +579,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.29.tgz",
-			"integrity": "sha512-DURisqWS3bUgiwMXTmzymVNGlcRW0FnbPZ3SZknhmxnCXm3n9idkTJ6T+Uir359KRKtJNFLRViskk8HsSVLi1w==",
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+			"integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.5",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -601,15 +597,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.33.tgz",
-			"integrity": "sha512-9y9obU4IQWru9f+NiiscUeyCe5ZmQav4FKEb1qfUNrik/C3BzBGUnHQWyPEyXjOX9cb+vx1TYx0qZBtinKdzTA==",
+			"version": "3.972.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+			"integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
-				"@aws-sdk/token-providers": "3.1034.0",
+				"@aws-sdk/core": "^3.974.5",
+				"@aws-sdk/nested-clients": "^3.997.3",
+				"@aws-sdk/token-providers": "3.1036.0",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -621,14 +617,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.33.tgz",
-			"integrity": "sha512-RazhlN0YAkna2T2p2v4YuuRlVBVRNo8V0SL+9JePTWDndEUAeOBAjYeQfAMbtDyCh120+zA0Op6V0jS4dw2+iw==",
+			"version": "3.972.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+			"integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.5",
+				"@aws-sdk/nested-clients": "^3.997.3",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -720,19 +716,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-ec2": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.13.tgz",
-			"integrity": "sha512-mcmO0xwjB+H68XMWBBrTD7w9fARzH7/vo7ZvJenicIGZP18tAqiETF/bDMNjtzfLbfANMBpGbn7/3lmt4dncdA==",
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.22.tgz",
+			"integrity": "sha512-i9BeGH8OIPXmDuu5VZEvq3QVzP2Upt0QJsW/0ziS873CJ+zFiCyobiqQ3QTgJpxIsBBXBswsRQajEG+PvuKxYg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-format-url": "^3.972.7",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/signature-v4": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-format-url": "^3.972.10",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -740,24 +736,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.32",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.32.tgz",
-			"integrity": "sha512-dc2O2x0V5pGJhmdQYQveUIFtMZsur7GrGuSgoKM4oQJuEcfvwnJ3sj+ip6WnxR5l6TrX5zkl4KgcgswOy3wAzQ==",
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+			"integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.5",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"@smithy/util-config-provider": "^4.2.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-stream": "^4.5.25",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -766,19 +762,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.33.tgz",
-			"integrity": "sha512-mqtT3Fo7xanWMk2SbAcKLGGI/q1GHWNrExBj7cnWP2W2mkTMheXB4ntJvwPZ1UxPrQobrsv2dWFXmaOJeSOiDg==",
+			"version": "3.972.35",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+			"integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.5",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-retry": "^4.3.4",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -786,49 +782,49 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.1.tgz",
-			"integrity": "sha512-Afc9hc2WZs3X4Jb8dnxyuYiZsLoWRO51roTCRf497gPnAKN2WRdXANu1vaVCTzwnDMOYFXb/cYv4ZSjxqAqcKA==",
+			"version": "3.997.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+			"integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.5",
 				"@aws-sdk/middleware-host-header": "^3.972.10",
 				"@aws-sdk/middleware-logger": "^3.972.10",
 				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.33",
+				"@aws-sdk/middleware-user-agent": "^3.972.35",
 				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.20",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.22",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
 				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.19",
+				"@aws-sdk/util-user-agent-node": "^3.973.21",
 				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/fetch-http-handler": "^5.3.17",
 				"@smithy/hash-node": "^4.2.14",
 				"@smithy/invalid-dependency": "^4.2.14",
 				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.31",
-				"@smithy/middleware-retry": "^4.5.4",
-				"@smithy/middleware-serde": "^4.2.19",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.5",
+				"@smithy/middleware-serde": "^4.2.20",
 				"@smithy/middleware-stack": "^4.2.14",
 				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/node-http-handler": "^4.6.1",
 				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"@smithy/url-parser": "^4.2.14",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-body-length-browser": "^4.2.2",
 				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.48",
-				"@smithy/util-defaults-mode-node": "^4.2.53",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
 				"@smithy/util-endpoints": "^3.4.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-retry": "^4.3.4",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -854,13 +850,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.20.tgz",
-			"integrity": "sha512-MEj6DhEcaO8RgVtFCJ+xpCQnZC3Iesr09avdY75qkMQfckQULu447IegK7Rs1MCGerVBfKnJQ4q+pQq9hI5lng==",
+			"version": "3.996.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+			"integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.32",
+				"@aws-sdk/middleware-sdk-s3": "^3.972.34",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/signature-v4": "^5.3.14",
@@ -872,14 +868,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1034.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1034.0.tgz",
-			"integrity": "sha512-8E+KGcD4ET0H9FXJ2/ZWbfFnQNYEkTZZYJxAs1lkdJlve1AYuqaydInIFfvNgoz5GbYtzbK8/ugsSMu5wPm6kA==",
+			"version": "3.1036.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+			"integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.5",
+				"@aws-sdk/nested-clients": "^3.997.3",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -935,15 +931,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-format-url": {
-			"version": "3.972.7",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.7.tgz",
-			"integrity": "sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA==",
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+			"integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.5",
-				"@smithy/querystring-builder": "^4.2.11",
-				"@smithy/types": "^4.13.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -976,13 +972,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.19",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.19.tgz",
-			"integrity": "sha512-ZAfHjpzdbrzkAftC139JoYGfXzDh5HY+AxRzw8pGJ8cULsf+l721sKAMK8mV5NvRETaW/BwghSwQhGgoNgrxMw==",
+			"version": "3.973.21",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+			"integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.33",
+				"@aws-sdk/middleware-user-agent": "^3.972.35",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/types": "^4.14.1",
@@ -2239,16 +2235,15 @@
 			}
 		},
 		"node_modules/@guardian/cdk": {
-			"version": "63.2.0",
-			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-63.2.0.tgz",
-			"integrity": "sha512-f5ttVoQNOlYyAVRVMtz3T3e7f7UyiRJxaXAOl6LZ57UXRMsHn+768ogZ3zab36ujVnArD0EvbJY4jTo8CDc36A==",
+			"version": "63.2.1",
+			"resolved": "git+ssh://git@github.com/guardian/cdk.git#f69a471635af4fd362c456bbf34c29df0523de3e",
 			"dev": true,
 			"dependencies": {
-				"@aws-sdk/client-ec2": "^3.1001.0",
-				"@aws-sdk/client-ssm": "^3.1001.0",
-				"@aws-sdk/credential-providers": "^3.1001.0",
+				"@aws-sdk/client-ec2": "^3.1034.0",
+				"@aws-sdk/client-ssm": "^3.1034.0",
+				"@aws-sdk/credential-providers": "^3.1034.0",
 				"chalk": "^4.1.2",
-				"codemaker": "^1.127.0",
+				"codemaker": "^1.128.0",
 				"git-url-parse": "^16.0.1",
 				"js-yaml": "^4.1.1",
 				"read-pkg-up": "7.0.1",
@@ -3053,9 +3048,9 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.16",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-			"integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+			"version": "3.23.17",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+			"integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3065,7 +3060,7 @@
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-body-length-browser": "^4.2.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-stream": "^4.5.25",
 				"@smithy/util-utf8": "^4.2.2",
 				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
@@ -3167,14 +3162,14 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.31",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
-			"integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
+			"version": "4.4.32",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+			"integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
-				"@smithy/middleware-serde": "^4.2.19",
+				"@smithy/core": "^3.23.17",
+				"@smithy/middleware-serde": "^4.2.20",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
 				"@smithy/types": "^4.14.1",
@@ -3187,20 +3182,20 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
-			"integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
+			"integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/service-error-classification": "^4.3.0",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-retry": "^4.3.4",
 				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
@@ -3209,13 +3204,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.19",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
-			"integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
+			"version": "4.2.20",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+			"integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
@@ -3255,9 +3250,9 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
-			"integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+			"integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3375,18 +3370,18 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.12.12",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
-			"integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
+			"version": "4.12.13",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+			"integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
-				"@smithy/middleware-endpoint": "^4.4.31",
+				"@smithy/core": "^3.23.17",
+				"@smithy/middleware-endpoint": "^4.4.32",
 				"@smithy/middleware-stack": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-stream": "^4.5.25",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3490,14 +3485,14 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.48",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
-			"integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
+			"version": "4.3.49",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+			"integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -3506,9 +3501,9 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.53",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
-			"integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
+			"version": "4.2.54",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+			"integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3516,7 +3511,7 @@
 				"@smithy/credential-provider-imds": "^4.2.14",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -3567,9 +3562,9 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
-			"integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
+			"integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3582,14 +3577,14 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.5.24",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
-			"integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
+			"version": "4.5.25",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+			"integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/node-http-handler": "^4.6.1",
 				"@smithy/types": "^4.14.1",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-buffer-from": "^4.2.2",
@@ -4792,10 +4787,8 @@
 				"jsonschema",
 				"semver"
 			],
-			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"jsonschema": "~1.4.1",
 				"semver": "^7.7.3"
@@ -4809,20 +4802,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
 			"version": "1.4.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
 			"version": "7.7.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4832,17 +4821,13 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
 			"version": "1.0.2",
-			"dev": true,
 			"inBundle": true,
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ajv": {
 			"version": "8.18.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4856,20 +4841,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -4882,30 +4863,24 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/astral-regex": {
 			"version": "2.0.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/balanced-match": {
 			"version": "4.0.4",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/brace-expansion": {
 			"version": "5.0.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
@@ -4915,20 +4890,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/case": {
 			"version": "1.6.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "(MIT OR GPL-3.0-or-later)",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/color-convert": {
 			"version": "2.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -4938,28 +4909,21 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/color-name": {
 			"version": "1.1.4",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fast-uri": {
 			"version": "3.1.0",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4971,15 +4935,12 @@
 				}
 			],
 			"inBundle": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fs-extra": {
 			"version": "11.3.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -4991,44 +4952,34 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/graceful-fs": {
 			"version": "4.2.11",
-			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ignore": {
 			"version": "5.3.2",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/jsonfile": {
 			"version": "6.2.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -5038,37 +4989,29 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/jsonschema": {
 			"version": "1.5.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
 			"version": "4.4.2",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/mime-db": {
 			"version": "1.52.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/mime-types": {
 			"version": "2.1.35",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
@@ -5078,10 +5021,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/minimatch": {
 			"version": "10.2.4",
-			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
 			},
@@ -5094,30 +5035,24 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/punycode": {
 			"version": "2.3.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/require-from-string": {
 			"version": "2.0.2",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/semver": {
 			"version": "7.7.4",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -5127,10 +5062,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/slice-ansi": {
 			"version": "4.0.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
@@ -5145,10 +5078,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/string-width": {
 			"version": "4.2.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -5160,10 +5091,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -5173,10 +5102,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/table": {
 			"version": "6.9.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -5190,20 +5117,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/universalify": {
 			"version": "2.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/yaml": {
 			"version": "1.10.2",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">= 6"
 			}
@@ -5578,9 +5501,9 @@
 			}
 		},
 		"node_modules/codemaker": {
-			"version": "1.127.0",
-			"resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.127.0.tgz",
-			"integrity": "sha512-iX64GnNH86f88aRj/McYBSNRKT+bn21Okng0v/aGI/G66uOx7bKAf5bhGiqSaip7s5OcXfvjyJ6iA0VhLL4bSg==",
+			"version": "1.128.0",
+			"resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.128.0.tgz",
+			"integrity": "sha512-QqIZBuVAE5wap5DJrIgk0v4pl2VRB5Bl3YWwPDloerM621fpgmzIm2lbw5hM+saV0zg+K+r4cCjWBVDIvRLExA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8590,9 +8513,9 @@
 			}
 		},
 		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@aws-sdk/client-auto-scaling": "3.1034.0",
 		"@aws-sdk/credential-providers": "3.1034.0",
-		"@guardian/cdk": "63.2.0",
+		"@guardian/cdk": "github:guardian/cdk#aa/riff-raff-yaml-comment",
 		"@guardian/eslint-config": "14.0.1",
 		"@guardian/prettier": "10.0.0",
 		"@types/aws-lambda": "8.10.161",


### PR DESCRIPTION
## What does this change?
Testing https://github.com/guardian/cdk/pull/2897, specifically to understand how https://github.com/guardian/actions-riff-raff behaves.

https://github.com/guardian/actions-riff-raff [recreates](https://github.com/guardian/actions-riff-raff/blob/1b8f1ef89e2c8041a78b933cc0a61a5b99298ae1/src/config.ts#L96-L121) the `riff-raff.yaml`, and thus the comments are lost. See also https://riffraff.gutools.co.uk/deployment/request/deployConfig?projectName=devx%3A%3Acdk-playground&id=2242.