### PR TITLE
feat(ecs): Read-only root file system

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -1298,6 +1298,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                 "Protocol": "tcp",
               },
             ],
+            "ReadonlyRootFilesystem": true,
             "VersionConsistency": "disabled",
           },
         ],

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -215,6 +215,7 @@ export class CdkPlaygroundEcs extends GuStack {
 			logging: LogDriver.awsLogs({
 				streamPrefix: 'cdk-playground-ecs',
 			}),
+			readonlyRootFilesystem: true,
 		});
 
 		// Here's an example of providing custom IAM permissions to the task role. cdk-playground doesn't actually need any


### PR DESCRIPTION
## What does this change?
To comply with [FSBP ECS.5](https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-5), make the root file system read-only.

## How has this change been tested?
After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/8b3f06d3-1be3-4304-9f22-f80c0ecc8b5d), the service is still accessible on https://cdk-playground-ecs.code.dev-gutools.co.uk:

<img width="508" height="245" alt="image" src="https://github.com/user-attachments/assets/8771aaaa-0073-4fc0-a20b-18887e84e73d" />

The AWS console also shows the root file system is now read-only:

<img width="244" height="88" alt="image" src="https://github.com/user-attachments/assets/a20ae1df-31b7-4903-94e9-2cce58ebf1cb" />
