### PR TITLE
feat(ecs): Configure ECS service to ship logs to Central ELK

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -383,7 +383,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   "Ref": "EcsTaskDefinitionLogShippingLogGroup0E405BD0",
                 },
                 "awslogs-region": "eu-west-1",
-                "awslogs-stream-prefix": "deploy/CODE/cdk-playground-ecs",
+                "awslogs-stream-prefix": "deploy/CODE/cdk-playground-ecs/devx-logs-sidecar",
               },
             },
             "MountPoints": [

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -6,6 +6,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     "gu:cdk:constructs": [
       "GuVpcParameter",
       "GuParameter",
+      "GuLoggingStreamNameParameter",
       "GuParameterStoreReadPolicy",
       "GuHttpsEgressSecurityGroup",
       "GuSubnetListParameter",
@@ -33,6 +34,11 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     "AccessLoggingBucket": {
       "Default": "/account/services/access-logging/bucket",
       "Description": "S3 bucket to store your access logs",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "VpcId": {
@@ -128,6 +134,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     },
     "EcsService81FC6EF6": {
       "DependsOn": [
+        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
         "ListenerCdkplaygroundecs3194EDCD",
       ],
@@ -205,6 +212,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     },
     "EcsServiceTaskCountTarget02FCCE22": {
       "DependsOn": [
+        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
       ],
       "Properties": {
@@ -320,13 +328,14 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
               ],
             },
             "LogConfiguration": {
-              "LogDriver": "awslogs",
+              "LogDriver": "awsfirelens",
               "Options": {
-                "awslogs-group": {
-                  "Ref": "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754",
+                "Name": "kinesis_streams",
+                "region": "eu-west-1",
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
                 },
-                "awslogs-region": "eu-west-1",
-                "awslogs-stream-prefix": "cdk-playground-ecs",
               },
             },
             "Name": "cdk-playground",
@@ -338,6 +347,54 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             ],
             "ReadonlyRootFilesystem": true,
             "VersionConsistency": "disabled",
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "CODE",
+              },
+              {
+                "Name": "APP",
+                "Value": "cdk-playground-ecs",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/cdk-playground",
+              },
+              {
+                "Name": "TASK_NAME",
+                "Value": "cdk-playground-ecs",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/devx-logs:2.1.0",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "EcsTaskDefinitionLogShippingLogGroup0E405BD0",
+                },
+                "awslogs-region": "eu-west-1",
+                "awslogs-stream-prefix": "deploy/CODE/cdk-playground-ecs",
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/init",
+                "ReadOnly": false,
+                "SourceVolume": "logging-volume",
+              },
+            ],
+            "Name": "LogShipping",
+            "ReadonlyRootFilesystem": true,
           },
         ],
         "Cpu": "1024",
@@ -377,6 +434,11 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Arn",
           ],
         },
+        "Volumes": [
+          {
+            "Name": "logging-volume",
+          },
+        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -456,7 +518,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
               "Effect": "Allow",
               "Resource": {
                 "Fn::GetAtt": [
-                  "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754",
+                  "EcsTaskDefinitionLogShippingLogGroup0E405BD0",
                   "Arn",
                 ],
               },
@@ -472,6 +534,32 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "EcsTaskDefinitionLogShippingLogGroup0E405BD0": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
     },
     "EcsTaskDefinitionTaskRoleB7B6D8DD": {
       "Properties": {
@@ -508,30 +596,47 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::IAM::Role",
     },
-    "EcsTaskDefinitioncdkplaygroundLogGroupF3F5A754": {
-      "DeletionPolicy": "Retain",
+    "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057": {
       "Properties": {
-        "Tags": [
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
+        "Roles": [
           {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
+            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
           },
         ],
       },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
+      "Type": "AWS::IAM::Policy",
     },
     "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490": {
       "Properties": {

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -1,5 +1,6 @@
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import {
+	GuLoggingStreamNameParameter,
 	GuParameter,
 	GuStack,
 	type GuStackProps,
@@ -25,9 +26,14 @@ import {
 	ContainerImage,
 	FargateService,
 	FargateTaskDefinition,
+	FireLensLogDriver,
+	FirelensLogRouterType,
 	LogDriver,
 	VersionConsistency,
 } from 'aws-cdk-lib/aws-ecs';
+import type { Volume } from 'aws-cdk-lib/aws-ecs';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	/**
@@ -50,6 +56,13 @@ export class CdkPlaygroundEcs extends GuStack {
 			stage: 'CODE',
 			env: { region: 'eu-west-1' },
 		});
+
+		const {
+			stack,
+			stage,
+			repositoryName = 'guardian/cdk-playground',
+			region,
+		} = this;
 
 		const { buildIdentifier } = props;
 		const ecsApp = 'cdk-playground-ecs';
@@ -92,6 +105,18 @@ export class CdkPlaygroundEcs extends GuStack {
 			`build-${buildIdentifier}`,
 		);
 
+		const loggingStreamName =
+			GuLoggingStreamNameParameter.getInstance(this).valueAsString;
+
+		const fireLensLogDriver = new FireLensLogDriver({
+			options: {
+				Name: `kinesis_streams`,
+				region,
+				stream: loggingStreamName,
+				retry_limit: '2',
+			},
+		});
+
 		// AWS::ECS::TaskDefinition
 		// AWS::IAM::Role ('execution role' - used for pulling image etc.)
 		// AWS::IAM::Role ('task role' - used for application's runtime permissions e.g. reading config from SSM)
@@ -110,12 +135,22 @@ export class CdkPlaygroundEcs extends GuStack {
 			// https://aws.amazon.com/blogs/containers/announcing-software-version-consistency-for-amazon-ecs-services/
 			versionConsistency: VersionConsistency.DISABLED,
 			portMappings: [{ containerPort: 9000 }],
-			// AWS::Logs::LogGroup
-			logging: LogDriver.awsLogs({
-				streamPrefix: 'cdk-playground-ecs',
-			}),
+			logging: fireLensLogDriver,
 			readonlyRootFilesystem: true,
 		});
+
+		const logShippingPolicy = new PolicyStatement({
+			actions: ['kinesis:Describe*', 'kinesis:Put*'],
+			effect: Effect.ALLOW,
+			resources: [
+				this.formatArn({
+					service: 'kinesis',
+					resource: 'stream',
+					resourceName: loggingStreamName,
+				}),
+			],
+		});
+		taskDefinition.addToTaskRolePolicy(logShippingPolicy);
 
 		// Here's an example of providing custom IAM permissions to the task role. cdk-playground doesn't actually need any
 		// but our pattern should provide some useful defaults, such as reading from parameter store
@@ -192,6 +227,44 @@ export class CdkPlaygroundEcs extends GuStack {
 			ttl: Duration.minutes(1),
 			domainName: ecsDomainName,
 			resourceRecord: loadBalancer.loadBalancerDnsName,
+		});
+
+		const logRouter = taskDefinition.addFirelensLogRouter('LogShipping', {
+			// See https://github.com/guardian/devx-logs
+			image: ContainerImage.fromRegistry('ghcr.io/guardian/devx-logs:2.1.0'),
+
+			// Required by https://github.com/guardian/devx-logs
+			environment: {
+				STACK: stack,
+				STAGE: stage,
+				APP: ecsApp,
+				GU_REPO: repositoryName,
+				TASK_NAME: ecsApp,
+			},
+
+			// Send this container's logs to CloudWatch logs, retained for 1 day
+			logging: LogDriver.awsLogs({
+				streamPrefix: [stack, stage, ecsApp].join('/'),
+				logRetention: RetentionDays.ONE_DAY,
+			}),
+
+			firelensConfig: {
+				type: FirelensLogRouterType.FLUENTBIT,
+			},
+
+			// To comply with FSBP ECS.5
+			readonlyRootFilesystem: true,
+		});
+
+		const logVolume: Volume = {
+			name: 'logging-volume',
+		};
+		taskDefinition.addVolume(logVolume);
+
+		logRouter.addMountPoints({
+			containerPath: '/init',
+			sourceVolume: logVolume.name,
+			readOnly: false,
 		});
 	}
 }

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -244,7 +244,7 @@ export class CdkPlaygroundEcs extends GuStack {
 
 			// Send this container's logs to CloudWatch logs, retained for 1 day
 			logging: LogDriver.awsLogs({
-				streamPrefix: [stack, stage, ecsApp].join('/'),
+				streamPrefix: [stack, stage, ecsApp, 'devx-logs-sidecar'].join('/'),
 				logRetention: RetentionDays.ONE_DAY,
 			}),
 


### PR DESCRIPTION
## What does this change?
Currently, the logs from the Play app running in ECS are being shipped to CloudWatch Logs. Whilst they are accessible, it would be better if they were co-located with the logs from the rest of the estate; the Central ELK stack. This change uses https://github.com/guardian/devx-logs/tree/main/ecs to add a fluentbit sidecar to write these logs to the Kinesis stream consumed by the Central ELK stack.

## How has this change been tested?
After [deploying](https://riffraff.gutools.co.uk/deployment/view/2cc8c2ae-e623-4456-847f-3acfb49def6c), we can see the [logs in Central ELK](https://logs.gutools.co.uk/s/devx/app/r/s/4EkAU):

<img width="1275" height="801" alt="image" src="https://github.com/user-attachments/assets/328d0a00-13e1-40f4-858d-23709332aa94" />
