### PR TITLE
fix(ecs): Add GuardDuty permissions

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -512,6 +512,15 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             },
             {
               "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate",
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -152,6 +152,35 @@ export class CdkPlaygroundEcs extends GuStack {
 		});
 		taskDefinition.addToTaskRolePolicy(logShippingPolicy);
 
+		/*
+		GuardDuty is enabled at the organisation level and runs as a sidecar.
+		We need to add specific permissions to allow pulling the GuardDuty image.
+		See https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html.
+		 */
+		const guardDutyPolicies = [
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['ecr:GetAuthorizationToken'],
+				resources: ['*'],
+			}),
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: [
+					'ecr:BatchCheckLayerAvailability',
+					'ecr:GetDownloadUrlForLayer',
+					'ecr:BatchGetImage',
+				],
+				resources: [
+					// See https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring-ecr-repository-gdu-agent.html
+					'arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate',
+				],
+			}),
+		];
+
+		guardDutyPolicies.forEach((policy) =>
+			taskDefinition.addToExecutionRolePolicy(policy),
+		);
+
 		// Here's an example of providing custom IAM permissions to the task role. cdk-playground doesn't actually need any
 		// but our pattern should provide some useful defaults, such as reading from parameter store
 		new GuParameterStoreReadPolicy(this, { app: ecsApp }).attachToRole(


### PR DESCRIPTION
## What does this change?
When testing #1089 I spotted this issue in the AWS console:

<img width="1407" height="492" alt="image" src="https://github.com/user-attachments/assets/8c527c68-d6ab-4ab1-b583-20d13f7401d7" />

GuardDuty is enabled at the organisation level and runs as a sidecar. We need specific permissions to allow pulling the GuardDuty image.

https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html lists the requirements for this. It looks like we're only missing permissions. This change updates our infrastructure with the required permissions.

Apply the same changes as https://github.com/guardian/service-catalogue/pull/1673 to resolve.

## How has this change been tested?
After [deploying](https://riffraff.gutools.co.uk/deployment/view/43372ae7-dc4e-4708-b887-6f4219203a93), the error seen above has resolved:

<img width="1395" height="488" alt="image" src="https://github.com/user-attachments/assets/3f64800c-48a3-44c5-b710-c9d324587994" />
