### PR TITLE
feat(cdk): Use image digest to determine which image to run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Build, tag, and push docker image to Amazon ECR
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }} # TODO Update https://github.com/guardian/riffraff-platform to add the ECR repository URI as a repository secret. This would allow us to login exactly before push, and no earlier.
+          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
           REPOSITORY: ${{ github.repository }}
           COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           BUILD_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,15 @@ jobs:
 
           sbt Docker/publishLocal
 
+      - name: Export image digest
+        env:
+          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
+          REPOSITORY: ${{ github.repository }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          IMAGE_DIGEST=$(docker inspect "$REGISTRY/$REPOSITORY:build-$BUILD_NUMBER" --format "{{.Id}}")
+          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_ENV
+
       - name: Push docker image to Amazon ECR
         env:
           REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,10 +75,9 @@ jobs:
         with:
           mask-password: 'true'
 
-      - name: Build, tag, and push docker image to Amazon ECR
+      - name: Build and tag docker image
         env:
           REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
-          REPOSITORY: ${{ github.repository }}
           COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           BUILD_NUMBER: ${{ github.run_number }}
           ORIGINAL_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
@@ -91,4 +90,9 @@ jobs:
 
           sbt Docker/publishLocal
 
+      - name: Push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
+          REPOSITORY: ${{ github.repository }}
+        run: |
           docker push $REGISTRY/$REPOSITORY --all-tags

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,45 +63,51 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           BUILD_NUMBER: ${{ github.run_number }}
         run: |
+          docker inspect "$REGISTRY/$REPOSITORY:build-$BUILD_NUMBER"
+
+          docker images --digests
+
           IMAGE_DIGEST=$(docker inspect "$REGISTRY/$REPOSITORY:build-$BUILD_NUMBER" --format "{{.Id}}")
           echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_ENV
 
-      # Build CDK and Play (in sequence)
-      - run: ./script/ci
+          echo $IMAGE_DIGEST
 
-      # Upload our build artifacts to Riff-Raff (well, S3)
-      - uses: guardian/actions-riff-raff@v4
-        with:
-          projectName: devx::cdk-playground
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          configPath: cdk/cdk.out/riff-raff.yaml
-          contentDirectories: |
-            cdk.out:
-              - cdk/cdk.out
-            cdk-playground:
-              - dist/cdk-playground
-            cdk-playground-lambda:
-              - lambda/cdk-playground-lambda.zip
-            event-forwarder:
-              - cdk/dist/event-forwarder.zip
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.0
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-          mask-aws-account-id: 'true'
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.3
-        with:
-          mask-password: 'true'
-
-      - name: Push docker image to Amazon ECR
-        env:
-          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          docker push $REGISTRY/$REPOSITORY --all-tags
+#      # Build CDK and Play (in sequence)
+#      - run: ./script/ci
+#
+#      # Upload our build artifacts to Riff-Raff (well, S3)
+#      - uses: guardian/actions-riff-raff@v4
+#        with:
+#          projectName: devx::cdk-playground
+#          githubToken: ${{ secrets.GITHUB_TOKEN }}
+#          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+#          configPath: cdk/cdk.out/riff-raff.yaml
+#          contentDirectories: |
+#            cdk.out:
+#              - cdk/cdk.out
+#            cdk-playground:
+#              - dist/cdk-playground
+#            cdk-playground-lambda:
+#              - lambda/cdk-playground-lambda.zip
+#            event-forwarder:
+#              - cdk/dist/event-forwarder.zip
+#
+#      - name: Configure AWS credentials
+#        uses: aws-actions/configure-aws-credentials@v6.1.0
+#        with:
+#          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+#          aws-region: eu-west-1
+#          mask-aws-account-id: 'true'
+#
+#      - name: Login to Amazon ECR
+#        id: login-ecr
+#        uses: aws-actions/amazon-ecr-login@v2.1.3
+#        with:
+#          mask-password: 'true'
+#
+#      - name: Push docker image to Amazon ECR
+#        env:
+#          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
+#          REPOSITORY: ${{ github.repository }}
+#        run: |
+#          docker push $REGISTRY/$REPOSITORY --all-tags

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,30 @@ jobs:
 
       - uses: guardian/setup-scala@v1
 
+      - name: Build and tag docker image
+        env:
+          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          ORIGINAL_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+        run: |
+          # Remove "refs/heads/" prefix from ORIGINAL_BRANCH_NAME
+          TRIMMED_BRANCH_NAME="${ORIGINAL_BRANCH_NAME#refs/heads/}"
+
+          # Replace / with - and export it to make it available to sbt
+          export BRANCH_NAME=${TRIMMED_BRANCH_NAME//\//-}
+
+          sbt Docker/publishLocal
+
+      - name: Export image digest
+        env:
+          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
+          REPOSITORY: ${{ github.repository }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          IMAGE_DIGEST=$(docker inspect "$REGISTRY/$REPOSITORY:build-$BUILD_NUMBER" --format "{{.Id}}")
+          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_ENV
+
       # Build CDK and Play (in sequence)
       - run: ./script/ci
 
@@ -74,30 +98,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2.1.3
         with:
           mask-password: 'true'
-
-      - name: Build and tag docker image
-        env:
-          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
-          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          BUILD_NUMBER: ${{ github.run_number }}
-          ORIGINAL_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
-        run: |
-          # Remove "refs/heads/" prefix from ORIGINAL_BRANCH_NAME
-          TRIMMED_BRANCH_NAME="${ORIGINAL_BRANCH_NAME#refs/heads/}"
-
-          # Replace / with - and export it to make it available to sbt
-          export BRANCH_NAME=${TRIMMED_BRANCH_NAME//\//-}
-
-          sbt Docker/publishLocal
-
-      - name: Export image digest
-        env:
-          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
-          REPOSITORY: ${{ github.repository }}
-          BUILD_NUMBER: ${{ github.run_number }}
-        run: |
-          IMAGE_DIGEST=$(docker inspect "$REGISTRY/$REPOSITORY:build-$BUILD_NUMBER" --format "{{.Id}}")
-          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_ENV
 
       - name: Push docker image to Amazon ECR
         env:

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -20,7 +20,7 @@ new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
 
 new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-ecs',
-	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+	imageIdentifier: process.env.IMAGE_DIGEST ?? 'DEV',
 });
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -323,7 +323,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/guardian/cdk-playground:build-TEST",
+                  "/guardian/cdk-playground:TEST",
                 ],
               ],
             },

--- a/cdk/lib/cdk-playground-ecs.test.ts
+++ b/cdk/lib/cdk-playground-ecs.test.ts
@@ -6,7 +6,7 @@ describe('The cdk-playground infrastructure definition', () => {
 	it('matches the snapshot for ECS', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
-			buildIdentifier: 'TEST',
+			imageIdentifier: 'TEST',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -37,13 +37,9 @@ import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	/**
-	 * Which application build to run.
-	 * This will typically match the build number provided by CI.
-	 *
-	 * @example
-	 * process.env.GITHUB_RUN_NUMBER
+	 * Which image to run.
 	 */
-	buildIdentifier: string;
+	imageIdentifier: string;
 }
 
 // For now, we provision all of this infrastructure via constructs as part of this repo.
@@ -64,7 +60,7 @@ export class CdkPlaygroundEcs extends GuStack {
 			region,
 		} = this;
 
-		const { buildIdentifier } = props;
+		const { imageIdentifier } = props;
 		const ecsApp = 'cdk-playground-ecs';
 		const ecsDomainName = 'cdk-playground-ecs.code.dev-gutools.co.uk';
 
@@ -102,7 +98,7 @@ export class CdkPlaygroundEcs extends GuStack {
 		// ECR repo are both in the Deploy Tools accoutn
 		const image = ContainerImage.fromEcrRepository(
 			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
-			`build-${buildIdentifier}`,
+			imageIdentifier,
 		);
 
 		const loggingStreamName =


### PR DESCRIPTION
> [!NOTE]
> Easiest to review [commit by commit](https://github.com/guardian/cdk-playground/pull/1092/commits).

## What does this change?
Switch to using the image digest as the identifier for the ECS task.

## How has this change been tested?
TBD.

## How can we measure success?
TBD.