### PR TITLE
ci: Move fact gathering to its own job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,35 @@ on:
     branches:
       - main
 jobs:
+  facts:
+    runs-on: ubuntu-slim
+    permissions: {} # This job doesn't need any permissions. Explicitly set it to an empty object to avoid inheriting any default permissions of the workflow.
+    outputs:
+      BRANCH_NAME: ${{ steps.set-facts.outputs.RAW_BRANCH_NAME }}
+      BRANCH_NAME_FOR_ECR: ${{ steps.set-facts.outputs.BRANCH_NAME_FOR_ECR }}
+      BUILD_NUMBER: ${{ steps.set-facts.outputs.BUILD_NUMBER }}
+      COMMIT_SHA: ${{ steps.set-facts.outputs.COMMIT_SHA }}
+    steps:
+      - name: Build facts
+        id: set-facts
+        env:
+          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }} # When invoked from `pull_request`, `github.sha` is not the latest commit of the feature branch. All other times, it is.
+        run: |
+          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_OUTPUT
+          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+
+          # Remove "refs/heads/" prefix from RAW_BRANCH_NAME
+          TRIMMED_BRANCH_NAME="${RAW_BRANCH_NAME#refs/heads/}"
+          BRANCH_NAME_FOR_ECR=${TRIMMED_BRANCH_NAME//\//-}
+
+          echo "BRANCH_NAME=${TRIMMED_BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "BRANCH_NAME_FOR_ECR=${BRANCH_NAME_FOR_ECR}" >> $GITHUB_OUTPUT
+
   CI:
     runs-on: ubuntu-latest
-
+    needs: [facts]
     permissions:
       contents: read
 
@@ -17,19 +43,6 @@ jobs:
       pull-requests: write #...to comment on PRs
 
     steps:
-      - name: Build facts
-        env:
-          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
-          BUILD_NUMBER: ${{ github.run_number }}
-          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }} # When invoked from `pull_request`, `github.sha` is not the latest commit of the feature branch. All other times, it is.
-        run: |
-          # Remove "refs/heads/" prefix from RAW_BRANCH_NAME
-          BRANCH_NAME="${RAW_BRANCH_NAME#refs/heads/}"
-
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_ENV
-          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_ENV
-
       # Checkout the branch
       - uses: actions/checkout@v6.0.2
 
@@ -77,18 +90,12 @@ jobs:
 
       - name: Build, tag, and push docker image to Amazon ECR
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }} # TODO Update https://github.com/guardian/riffraff-platform to add the ECR repository URI as a repository secret. This would allow us to login exactly before push, and no earlier.
+          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
           REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          BUILD_NUMBER: ${{ github.run_number }}
-          ORIGINAL_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+          COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
+          BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
+          BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME_FOR_ECR }}
         run: |
-          # Remove "refs/heads/" prefix from ORIGINAL_BRANCH_NAME
-          TRIMMED_BRANCH_NAME="${ORIGINAL_BRANCH_NAME#refs/heads/}"
-
-          # Replace / with - and export it to make it available to sbt
-          export BRANCH_NAME=${TRIMMED_BRANCH_NAME//\//-}
-
           sbt Docker/publishLocal
 
           docker push $REGISTRY/$REPOSITORY --all-tags


### PR DESCRIPTION
## What does this change?
This change moves to separate parts of the CI process across multiple [jobs](https://docs.github.com/en/actions/get-started/understand-github-actions#jobs):

<img width="650" height="262" alt="image" src="https://github.com/user-attachments/assets/cac7c436-dcd8-4692-bc8e-455cd3c21fc8" />

## How has this change been tested?
CI passing should suffice.

## How can we measure success?
This approach will help inform the implementation of #1092.
