### PR TITLE
feat(cdk): Use image digest to determine which image to run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,44 @@ jobs:
           echo "BRANCH_NAME=${TRIMMED_BRANCH_NAME}" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME_FOR_ECR=${BRANCH_NAME_FOR_ECR}" >> $GITHUB_OUTPUT
 
+  ci-image:
+    runs-on: ubuntu-latest
+    needs: [facts]
+    permissions:
+      contents: read
+      id-token: write # Required to exchange for AWS credentials using OIDC
+    env:
+      REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
+      REPOSITORY: ${{ github.repository }}
+      COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
+      BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
+      BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME_FOR_ECR }}
+    outputs:
+      IMAGE_DIGEST: ${{ steps.obtain-image-digest.outputs.IMAGE_DIGEST }}
+    steps:
+      # Checkout the branch
+      - uses: actions/checkout@v6.0.2
+      - uses: guardian/setup-scala@v1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+          mask-aws-account-id: 'true'
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.1.3
+        with:
+          mask-password: 'true'
+      - name: Build, tag, and push docker image to Amazon ECR
+        run: |
+          sbt Docker/publishLocal
+          docker push $REGISTRY/$REPOSITORY --all-tags
+      - name: Obtain image digest
+        id: obtain-image-digest
+        run: |
+          IMAGE_DIGEST=$(docker manifest inspect $REGISTRY/$REPOSITORY:sha-$COMMIT_SHA --verbose | jq -r '.Descriptor.digest')
+          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
   CI:
     runs-on: ubuntu-latest
     needs:
@@ -79,28 +117,3 @@ jobs:
               - lambda/cdk-playground-lambda.zip
             event-forwarder:
               - cdk/dist/event-forwarder.zip
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.0
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-          mask-aws-account-id: 'true'
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.3
-        with:
-          mask-password: 'true'
-
-      - name: Build, tag, and push docker image to Amazon ECR
-        env:
-          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
-          REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
-          BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
-          BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME_FOR_ECR }}
-        run: |
-          sbt Docker/publishLocal
-
-          docker push $REGISTRY/$REPOSITORY --all-tags

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - facts
+      - ci-image
     permissions:
       contents: read
 
@@ -100,6 +101,7 @@ jobs:
           COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
           BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
           BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME }}
+          IMAGE_DIGEST: ${{ needs.ci-image.outputs.IMAGE_DIGEST }}
 
       # Upload our build artifacts to Riff-Raff (well, S3)
       - uses: guardian/actions-riff-raff@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,9 +6,36 @@ on:
     branches:
       - main
 jobs:
+  facts:
+    runs-on: ubuntu-slim
+    permissions: {} # This job doesn't need any permissions. Explicitly set it to an empty object to avoid inheriting any default permissions of the workflow.
+    outputs:
+      BRANCH_NAME: ${{ steps.set-facts.outputs.BRANCH_NAME }}
+      BRANCH_NAME_FOR_ECR: ${{ steps.set-facts.outputs.BRANCH_NAME_FOR_ECR }}
+      BUILD_NUMBER: ${{ steps.set-facts.outputs.BUILD_NUMBER }}
+      COMMIT_SHA: ${{ steps.set-facts.outputs.COMMIT_SHA }}
+    steps:
+      - name: Build facts
+        id: set-facts
+        env:
+          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+          BUILD_NUMBER: ${{ github.run_number }}
+          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }} # When invoked from `pull_request`, `github.sha` is not the latest commit of the feature branch. All other times, it is.
+        run: |
+          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_OUTPUT
+          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+
+          # Remove "refs/heads/" prefix from RAW_BRANCH_NAME
+          TRIMMED_BRANCH_NAME="${RAW_BRANCH_NAME#refs/heads/}"
+          BRANCH_NAME_FOR_ECR=${TRIMMED_BRANCH_NAME//\//-}
+
+          echo "BRANCH_NAME=${TRIMMED_BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "BRANCH_NAME_FOR_ECR=${BRANCH_NAME_FOR_ECR}" >> $GITHUB_OUTPUT
+
   CI:
     runs-on: ubuntu-latest
-
+    needs:
+      - facts
     permissions:
       contents: read
 
@@ -17,19 +44,6 @@ jobs:
       pull-requests: write #...to comment on PRs
 
     steps:
-      - name: Build facts
-        env:
-          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
-          BUILD_NUMBER: ${{ github.run_number }}
-          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }} # When invoked from `pull_request`, `github.sha` is not the latest commit of the feature branch. All other times, it is.
-        run: |
-          # Remove "refs/heads/" prefix from RAW_BRANCH_NAME
-          BRANCH_NAME="${RAW_BRANCH_NAME#refs/heads/}"
-
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_ENV
-          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_ENV
-
       # Checkout the branch
       - uses: actions/checkout@v6.0.2
 
@@ -44,6 +58,10 @@ jobs:
 
       # Build CDK and Play (in sequence)
       - run: ./script/ci
+        env:
+          COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
+          BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
+          BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME }}
 
       # Upload our build artifacts to Riff-Raff (well, S3)
       - uses: guardian/actions-riff-raff@v4
@@ -77,18 +95,12 @@ jobs:
 
       - name: Build, tag, and push docker image to Amazon ECR
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }} # TODO Update https://github.com/guardian/riffraff-platform to add the ECR repository URI as a repository secret. This would allow us to login exactly before push, and no earlier.
+          REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
           REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          BUILD_NUMBER: ${{ github.run_number }}
-          ORIGINAL_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
+          COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
+          BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
+          BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME_FOR_ECR }}
         run: |
-          # Remove "refs/heads/" prefix from ORIGINAL_BRANCH_NAME
-          TRIMMED_BRANCH_NAME="${ORIGINAL_BRANCH_NAME#refs/heads/}"
-
-          # Replace / with - and export it to make it available to sbt
-          export BRANCH_NAME=${TRIMMED_BRANCH_NAME//\//-}
-
           sbt Docker/publishLocal
 
           docker push $REGISTRY/$REPOSITORY --all-tags

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -20,7 +20,7 @@ new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
 
 new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-ecs',
-	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+	imageIdentifier: process.env.IMAGE_DIGEST ?? 'DEV',
 });
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -323,7 +323,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/guardian/cdk-playground:build-TEST",
+                  "/guardian/cdk-playground@sha256:12345",
                 ],
               ],
             },

--- a/cdk/lib/cdk-playground-ecs.test.ts
+++ b/cdk/lib/cdk-playground-ecs.test.ts
@@ -6,7 +6,7 @@ describe('The cdk-playground infrastructure definition', () => {
 	it('matches the snapshot for ECS', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
-			buildIdentifier: 'TEST',
+			imageIdentifier: 'sha256:12345',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -37,13 +37,12 @@ import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	/**
-	 * Which application build to run.
-	 * This will typically match the build number provided by CI.
+	 * Which image to run.
+	 * This should be the image digest (e.g. 'sha256:abc123') to ensure immutable deployments.
 	 *
-	 * @example
-	 * process.env.GITHUB_RUN_NUMBER
+	 * @see https://docs.docker.com/dhi/core-concepts/digests
 	 */
-	buildIdentifier: string;
+	imageIdentifier: string;
 }
 
 // For now, we provision all of this infrastructure via constructs as part of this repo.
@@ -64,7 +63,7 @@ export class CdkPlaygroundEcs extends GuStack {
 			region,
 		} = this;
 
-		const { buildIdentifier } = props;
+		const { imageIdentifier } = props;
 		const ecsApp = 'cdk-playground-ecs';
 		const ecsDomainName = 'cdk-playground-ecs.code.dev-gutools.co.uk';
 
@@ -102,7 +101,7 @@ export class CdkPlaygroundEcs extends GuStack {
 		// ECR repo are both in the Deploy Tools accoutn
 		const image = ContainerImage.fromEcrRepository(
 			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
-			`build-${buildIdentifier}`,
+			imageIdentifier,
 		);
 
 		const loggingStreamName =

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -98,7 +98,7 @@ export class CdkPlaygroundEcs extends GuStack {
 		});
 
 		// Need to figure out how to make this cross-account, but this is fine for the simple case where the app and the
-		// ECR repo are both in the Deploy Tools accoutn
+		// ECR repo are both in the Deploy Tools account
 		const image = ContainerImage.fromEcrRepository(
 			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
 			imageIdentifier,


### PR DESCRIPTION
> [!NOTE]
> - Requires https://github.com/guardian/riffraff-platform/pull/748
> - Recommended to review [commit by commit](https://github.com/guardian/cdk-playground/pull/1094/commits)

## Context
When deciding which image to run, there are a few options:
- Using a tag, e.g. `docker pull my-app:build-100`
- Using a digest, e.g. `docker pull my-app@sha256:abc123`

We [currently use the `build` tag](https://github.com/guardian/cdk-playground/blob/7b1af42dc73fb9348521c018a434c6d343d76490/cdk/lib/cdk-playground-ecs.ts#L103-L106).

An image's tags are decided by us. We [currently set tags](https://github.com/guardian/cdk-playground/blob/7b1af42dc73fb9348521c018a434c6d343d76490/build.sbt#L59-L69) for:
- `sha` representing the git commit hash
- `build` representing the CI build number
- `branch` representing the git branch name

Tags are convenient aliases, however as they can be mutated by default, they make environments non-deterministic.

In https://github.com/guardian/riffraff-platform/pull/739 we made the `build` tag immutable, increasing determinism. A consequence, however, is [re-runs](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs) of workflows are not possible. In this scenario, the build number (and thus `build` tag) does not change, violating the tag's immutability.

An [image's digest](https://docs.docker.com/dhi/core-concepts/digests) is automatically calculated by the registry and is immutable. If we use this, we can make the `build` tag mutable again, enabling the capability to re-run workflows, while still ensuring determinism of which image is used.

## What does this change?
This change updates how the CloudFormation stack references an image in ECR, changing from using the `build` tag to using the image's digest.

The digest is obtained in CI using [`docker manifest inspect`](https://docs.docker.com/reference/cli/docker/manifest/inspect/).

> [!NOTE]
> Though this requires https://github.com/guardian/riffraff-platform/pull/748, I've (temporarily) added the additional permissions directly to the IAM Role via the AWS console.

Whilst `docker manifest` is marked as experimental, it was the most reliable way of obtaining the digest. Alternative methods explored included:
- `docker images --digests`
  This works, however it produced results in tabular form which we'd then have to use `awk` or similar to extract the value.
- `docker images --digests --format "{{.Digest}}"`
  This returned the digest of the _local_ image. Strangely, this differs from the digest of the remote image. Research[^1] suggests this is due to different compression being used on each side.
- `docker inspect --format "{{.Id}}"`
  Similar to above, this returns the value of the local image.

To achieve this, the CI steps have been reorganised too.

Previously, it was:
1. Checkout repo
2. Synth CDK stack
3. Build EC2 artifact
4. Push artifacts to Riff-Raff
5. Build and push image to ECR

<details><summary>CI graph before</summary>
<p>

<img width="890" height="250" alt="image" src="https://github.com/user-attachments/assets/8702fdeb-6f5b-4b9a-a289-18602393461e" />

</p>
</details> 

Now it is:
1. Checkout repo
2. Build and push image to ECR
3. Synth CDK stack
4. Build EC2 artifact
5. Push artifacts to Riff-Raff

<details><summary>CI graph now</summary>
<p>

<img width="898" height="256" alt="image" src="https://github.com/user-attachments/assets/ab99d1b0-c944-4c4a-934c-4b2a05e66b93" />

</p>
</details> 

The "Build and push image to ECR" step requires authentication to AWS. To ensure only the necessary steps have access to AWS credentials, the steps are split across multiple (isolated compute) [jobs](https://docs.github.com/en/actions/get-started/understand-github-actions#jobs).

## How has this change been tested?
### Build facts
I've successfully [deployed this branch](https://riffraff.gutools.co.uk/deployment/view/973a0349-f4dc-43dd-b7f4-5a5da660ac66). Once deployed, the manifest for the EC2 app and ECS app continue to reference the correct build number, commit sha and branch name:

<img width="511" height="251" alt="image" src="https://github.com/user-attachments/assets/c330a84b-4bbd-4229-b2bc-41c38cf28dc0" />

<img width="514" height="255" alt="image" src="https://github.com/user-attachments/assets/d7d4a30f-6970-4ab5-9d55-4131a0312ff0" />

### Image reference
To confirm the ECS task definition's reference to the image, we can check the resource:

```bash
# Find the resource created from our CloudFormation stack
TASK_ARN=$(
  aws cloudformation describe-stack-resources \
    --stack-name deploy-CODE-cdk-playground-ecs \
    --profile deployTools \
    --region eu-west-1 \
    | jq -r '.StackResources[] | select(.ResourceType == "AWS::ECS::TaskDefinition") | .PhysicalResourceId'
)

aws ecs describe-task-definition \
  --task-definition $TASK_ARN \
  --profile deployTools \
  --region eu-west-1 \
  | jq -r '.taskDefinition.containerDefinitions[] | select(.name == "cdk-playground") | .image | split("@")[1]'
```

We can then compare this to the digest of the image produced from this branch:

```bash
ACCOUNT_ID=$(aws sts get-caller-identity --profile deployTools | jq -r .Account)
REGISTRY="${ACCOUNT_ID}.dkr.ecr.eu-west-1.amazonaws.com"
IMAGE="${REGISTRY}/guardian/cdk-playground:branch-aa-image-digest"

# Login to AWS ECR https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html
aws ecr get-login-password --profile deployTools --region eu-west-1 | docker login --username AWS --password-stdin $REGISTRY

docker manifest inspect $IMAGE --verbose | jq -r '.Descriptor.digest'
```

The two values should match.

## How can we measure success?
Success is regaining the ability to re-run workflows[^2], while ensuring deploys are deterministic, using an immutable image reference.

The benefits of https://github.com/guardian/cdk-playground/pull/1077 also remain.

[^1]: Chats with Gemini, which cites "Docker Image Spec v1.2", "OCI Distribution Spec", and "Docker Registry V2 API".
[^2]: Requires a PR to https://github.com/guardian/riffraff-platform to make the `build` tag mutable again.
