### PR TITLE
feat(ecs): Enable Riff-Raff redeployment

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "GuVpcParameter",
       "GuParameter",
       "GuLoggingStreamNameParameter",
+      "GuRiffRaffDeploymentIdParameter",
       "GuParameterStoreReadPolicy",
       "GuHttpsEgressSecurityGroup",
       "GuSubnetListParameter",
@@ -40,6 +41,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "RiffRaffDeploymentId": {
+      "Description": "Used by Riff-Raff to inject the deployment ID.",
+      "Type": "String",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
@@ -311,6 +316,11 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Properties": {
         "ContainerDefinitions": [
           {
+            "DockerLabels": {
+              "RiffRaffDeploymentId": {
+                "Ref": "RiffRaffDeploymentId",
+              },
+            },
             "Essential": true,
             "Image": {
               "Fn::Join": [

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -17,8 +17,9 @@ import {
 	GuApplicationTargetGroup,
 	GuHttpsApplicationListener,
 } from '@guardian/cdk/lib/constructs/loadbalancing';
+import { isSingletonPresentInStack } from '@guardian/cdk/lib/utils/singleton';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import { CfnParameter, Duration } from 'aws-cdk-lib';
 import { Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
 import {
@@ -34,6 +35,27 @@ import {
 import type { Volume } from 'aws-cdk-lib/aws-ecs';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+
+// This construct is already present in GuCDK as part of `GuEc2AppExperimental`, however it is not exported.
+// TODO Update GuCDK to export this construct.
+class GuRiffRaffDeploymentIdParameter extends CfnParameter {
+	private static instance: GuRiffRaffDeploymentIdParameter | undefined;
+
+	private constructor(scope: GuStack) {
+		super(scope, 'RiffRaffDeploymentId', {
+			type: 'String',
+			description: 'Used by Riff-Raff to inject the deployment ID.',
+		});
+	}
+
+	public static getInstance(stack: GuStack): GuRiffRaffDeploymentIdParameter {
+		if (!this.instance || !isSingletonPresentInStack(stack, this.instance)) {
+			this.instance = new GuRiffRaffDeploymentIdParameter(stack);
+		}
+
+		return this.instance;
+	}
+}
 
 interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	/**
@@ -131,6 +153,10 @@ export class CdkPlaygroundEcs extends GuStack {
 
 		taskDefinition.addContainer('cdk-playground', {
 			image,
+			dockerLabels: {
+				RiffRaffDeploymentId:
+					GuRiffRaffDeploymentIdParameter.getInstance(this).valueAsString,
+			},
 			// This speeds up deployment, but we should probably only use it in conjunction with immutable tags
 			// https://aws.amazon.com/blogs/containers/announcing-software-version-consistency-for-amazon-ecs-services/
 			versionConsistency: VersionConsistency.DISABLED,


### PR DESCRIPTION
## What does this change?
Today, a redeployment of the same build is a no-op as there is no CloudFormation changeset.

This change sets the [`DockerLabels` property](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ecs-taskdefinition-containerdefinition.html#cfn-ecs-taskdefinition-containerdefinition-dockerlabels) of a `AWS::ECS::TaskDefinition`'s `ContainerDefinition` to include the Riff-Raff deployment ID (see also https://github.com/guardian/riff-raff/pull/1469). Updates to `DockerLabels` is a replacement operation. Now when a redeployment is performed, Riff-Raff will inject a new value yielding a CloudFormation change.

See also https://docs.docker.com/engine/manage-resources/labels.

## How has this change been tested?
When `main` is [deployed](https://riffraff.gutools.co.uk/deployment/view/d5b3280c-af1a-4119-96ff-4b62e26aaa68) and then [redeployed](https://riffraff.gutools.co.uk/deployment/view/f4135a2b-5bc8-45e1-acc5-011a9ec5f31b), we can see there are no CloudFormation updates:

<img width="1116" height="264" alt="image" src="https://github.com/user-attachments/assets/0720bf64-8215-44a9-aec2-5d7dd6d5073c" />

After [deploying this branch](https://riffraff.gutools.co.uk/deployment/view/79530dfa-5715-448f-b556-a9dec3bfd395) and then [deploying](https://riffraff.gutools.co.uk/deployment/view/06ea8d36-e998-4bc9-acf3-b5be8303ccae) it again, we see a CloudFormation update:

<img width="1131" height="274" alt="image" src="https://github.com/user-attachments/assets/75a9833d-8957-4aa0-8c85-d788842b3b31" />

## How can we measure success?
Redeployments of the same build are possible.