### PR TITLE
fix: Apply `gu:riff-raff-project` tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
           projectName: devx::cdk-playground
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          configPath: cdk/cdk.out/riff-raff.yaml
+          configPath: cdk/cdk.out/devx::cdk-playground/riff-raff.yaml
           contentDirectories: |
             cdk.out:
               - cdk/cdk.out

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -5,22 +5,29 @@ import { CdkPlaygroundEcs } from '../lib/cdk-playground-ecs';
 import { CdkPlaygroundLambda } from '../lib/cdk-playground-lambda';
 import { EventForwarder } from '../lib/event-forwarder';
 
+const riffRaffProjectName = 'devx::cdk-playground';
+
 const app = new GuRoot();
 
-const eventForwarder = new EventForwarder(app, 'EventForwarder-CODE');
+const eventForwarder = new EventForwarder(app, 'EventForwarder-CODE', {
+	riffRaffProjectName,
+});
 
 const ec2Stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-ec2',
 	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+	riffRaffProjectName,
 });
 
 new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-lambda',
+	riffRaffProjectName,
 });
 
 new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-ecs',
 	imageIdentifier: process.env.IMAGE_DIGEST ?? 'DEV',
+	riffRaffProjectName,
 });
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.

--- a/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
@@ -161,6 +161,11 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "PropagateAtLaunch": true,
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "LogKinesisStreamName",
             "PropagateAtLaunch": true,
             "Value": {
@@ -227,6 +232,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Name",
@@ -347,6 +356,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -449,6 +462,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -542,6 +559,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -578,6 +599,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -725,6 +750,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -805,6 +834,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   "Value": "guardian/cdk-playground",
                 },
                 {
+                  "Key": "gu:riff-raff-project",
+                  "Value": "devx::cdk-playground",
+                },
+                {
                   "Key": "Name",
                   "Value": "CdkPlaygroundEc2-CODE/deploy-CODE-cdk-playground",
                 },
@@ -836,6 +869,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                 {
                   "Key": "gu:repo",
                   "Value": "guardian/cdk-playground",
+                },
+                {
+                  "Key": "gu:riff-raff-project",
+                  "Value": "devx::cdk-playground",
                 },
                 {
                   "Key": "Name",
@@ -929,6 +966,10 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
               {
                 "Key": "gu:repo",
                 "Value": "guardian/cdk-playground",
+              },
+              {
+                "Key": "gu:riff-raff-project",
+                "Value": "devx::cdk-playground",
               },
               {
                 "Key": "Name",

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -80,6 +80,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Name",
             "Value": "CdkPlaygroundEcs-CODE/CertificateCdkplaygroundecs",
           },
@@ -107,6 +111,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -201,6 +209,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -284,6 +296,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -430,6 +446,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -474,6 +494,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -568,6 +592,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -602,6 +630,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -681,6 +713,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -800,6 +836,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -836,6 +876,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",

--- a/cdk/lib/__snapshots__/cdk-playground-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-lambda.test.ts.snap
@@ -61,6 +61,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Name",
             "Value": "CdkPlaygroundLambda-CODE/CertificateCdkplaygroundlambda",
           },
@@ -140,6 +144,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -192,6 +200,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -313,6 +325,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -494,6 +510,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -506,7 +526,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "lambdacdkplaygroundlambdaapiDeployment157471B28266d1e345dae549af9ec84edc7f0bc3": {
+    "lambdacdkplaygroundlambdaapiDeployment157471B2fe4f0cb0700525e097b6f84513cf7205": {
       "DependsOn": [
         "lambdacdkplaygroundlambdaapiproxyANYDB984CB2",
         "lambdacdkplaygroundlambdaapiproxyFA4DE6D2",
@@ -529,7 +549,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "lambdacdkplaygroundlambdaapiDeployment157471B28266d1e345dae549af9ec84edc7f0bc3",
+          "Ref": "lambdacdkplaygroundlambdaapiDeployment157471B2fe4f0cb0700525e097b6f84513cf7205",
         },
         "RestApiId": {
           "Ref": "lambdacdkplaygroundlambdaapi061BB942",
@@ -547,6 +567,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",
@@ -583,6 +607,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",

--- a/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
+++ b/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
@@ -65,6 +65,10 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -149,6 +153,10 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -216,6 +224,10 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
             "Value": "guardian/cdk-playground",
           },
           {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -268,6 +280,10 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
           {
             "Key": "gu:repo",
             "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "devx::cdk-playground",
           },
           {
             "Key": "Stack",

--- a/cdk/lib/cdk-playground-ec2.test.ts
+++ b/cdk/lib/cdk-playground-ec2.test.ts
@@ -7,6 +7,7 @@ describe('The cdk-playground infrastructure definition', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
 			buildIdentifier: 'TEST',
+			riffRaffProjectName: 'devx::cdk-playground',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/cdk-playground-ecs.test.ts
+++ b/cdk/lib/cdk-playground-ecs.test.ts
@@ -7,6 +7,7 @@ describe('The cdk-playground infrastructure definition', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 			imageIdentifier: 'sha256:12345',
+			riffRaffProjectName: 'devx::cdk-playground',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/cdk-playground-lambda.test.ts
+++ b/cdk/lib/cdk-playground-lambda.test.ts
@@ -5,7 +5,9 @@ import { CdkPlaygroundLambda } from './cdk-playground-lambda';
 describe('The cdk-playground infrastructure definition', () => {
 	it('matches the snapshot for Lambda', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
-		const stack = new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {});
+		const stack = new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {
+			riffRaffProjectName: 'devx::cdk-playground',
+		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});
 });

--- a/cdk/lib/event-forwarder.test.ts
+++ b/cdk/lib/event-forwarder.test.ts
@@ -5,7 +5,9 @@ import { EventForwarder } from './event-forwarder';
 describe('The EventForwarder stack', () => {
 	it('matches the snapshot for CODE', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
-		const stack = new EventForwarder(app, 'EventForwarder-CODE');
+		const stack = new EventForwarder(app, 'EventForwarder-CODE', {
+			riffRaffProjectName: 'devx::cdk-playground',
+		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/event-forwarder.ts
+++ b/cdk/lib/event-forwarder.ts
@@ -1,3 +1,4 @@
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
@@ -7,11 +8,14 @@ import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 
+export type EventForwarderProps = Omit<GuStackProps, 'stack' | 'stage'>;
+
 export class EventForwarder extends GuStack {
-	constructor(scope: App, id: string) {
+	constructor(scope: App, id: string, props: EventForwarderProps) {
 		const app = 'event-forwarder';
 
 		super(scope, id, {
+			...props,
 			stack: 'deploy',
 			stage: 'CODE',
 			app,


### PR DESCRIPTION
## What does this change?
See https://github.com/guardian/cdk/releases/tag/v63.0.0 for notes on this GuCDK feature. This change adds a new `gu:riff-raff-project` tag to aid discovery, for example on the [Availability dashboard](https://metrics.gutools.co.uk/d/zM0ouzs4z/availability-dashboard).

## How has this change been tested?
See updated snapshot.
