### PR TITLE
[Step 1] Proof of concept for ECS migration (GuEcsApp)

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -12,6 +12,7 @@ const eventForwarder = new EventForwarder(app, 'EventForwarder-CODE');
 const ec2Stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-ec2',
 	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
+	imageIdentifier: process.env.IMAGE_DIGEST ?? 'DEV',
 });
 
 new CdkPlaygroundLambda(app, 'CdkPlaygroundLambda-CODE', {

--- a/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
@@ -24,7 +24,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
-      "GuRiffRaffDeploymentIdParameter",
+      "GuRiffRaffDeploymentIdParameterExperimental",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",

--- a/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
@@ -25,6 +25,11 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuRiffRaffDeploymentIdParameterExperimental",
+      "GuEcsAppExperimental",
+      "GuParameter",
+      "GuParameterStoreReadPolicy",
+      "GuHttpsEgressSecurityGroup",
+      "GuApplicationTargetGroup",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -68,6 +73,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "VpcPrivateSubnetsParam": {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Type": "AWS::SSM::Parameter::Value<List<String>>",
     },
     "cdkplaygroundPrivateSubnets": {
       "Default": "/account/vpc/primary/subnets/private",
@@ -289,6 +298,549 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "Guardian::DNS::RecordSet",
     },
+    "EcsCluster97242B84": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "EcsService81FC6EF6": {
+      "DependsOn": [
+        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
+        "EcsTaskDefinitionTaskRoleB7B6D8DD",
+        "ListenerCdkplaygroundA8D9CA6F",
+      ],
+      "Properties": {
+        "Cluster": {
+          "Ref": "EcsCluster97242B84",
+        },
+        "DeploymentConfiguration": {
+          "Alarms": {
+            "AlarmNames": [],
+            "Enable": false,
+            "Rollback": false,
+          },
+          "DeploymentCircuitBreaker": {
+            "Enable": true,
+            "Rollback": true,
+          },
+          "MaximumPercent": 200,
+          "MinimumHealthyPercent": 100,
+        },
+        "DeploymentController": {
+          "Type": "ECS",
+        },
+        "EnableECSManagedTags": false,
+        "HealthCheckGracePeriodSeconds": 60,
+        "LaunchType": "FARGATE",
+        "LoadBalancers": [
+          {
+            "ContainerName": "cdk-playground",
+            "ContainerPort": 9000,
+            "TargetGroupArn": {
+              "Ref": "EcsTargetGroupCdkplayground55757231",
+            },
+          },
+        ],
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": [
+              {
+                "Fn::GetAtt": [
+                  "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
+                  "GroupId",
+                ],
+              },
+            ],
+            "Subnets": {
+              "Ref": "VpcPrivateSubnetsParam",
+            },
+          },
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TaskDefinition": {
+          "Ref": "EcsTaskDefinition63157ED3",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "EcsServiceTaskCountTarget02FCCE22": {
+      "DependsOn": [
+        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
+        "EcsTaskDefinitionTaskRoleB7B6D8DD",
+      ],
+      "Properties": {
+        "MaxCapacity": 10,
+        "MinCapacity": 1,
+        "ResourceId": {
+          "Fn::Join": [
+            "",
+            [
+              "service/",
+              {
+                "Ref": "EcsCluster97242B84",
+              },
+              "/",
+              {
+                "Fn::GetAtt": [
+                  "EcsService81FC6EF6",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+        "RoleARN": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":iam::",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService",
+            ],
+          ],
+        },
+        "ScalableDimension": "ecs:service:DesiredCount",
+        "ServiceNamespace": "ecs",
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
+    },
+    "EcsTargetGroupCdkplayground55757231": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Name": "cdk-playground-CODE",
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "EcsTaskDefinition63157ED3": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "DockerLabels": {
+              "RiffRaffDeploymentId": {
+                "Ref": "RiffRaffDeploymentId",
+              },
+            },
+            "Essential": true,
+            "Image": {
+              "Fn::Join": [
+                "",
+                [
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ".dkr.ecr.eu-west-1.",
+                  {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/guardian/cdk-playground@sha256:12345",
+                ],
+              ],
+            },
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": "eu-west-1",
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "cdk-playground",
+            "PortMappings": [
+              {
+                "ContainerPort": 9000,
+                "Protocol": "tcp",
+              },
+            ],
+            "ReadonlyRootFilesystem": true,
+            "VersionConsistency": "disabled",
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "CODE",
+              },
+              {
+                "Name": "APP",
+                "Value": "cdk-playground",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/cdk-playground",
+              },
+              {
+                "Name": "TASK_NAME",
+                "Value": "cdk-playground",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/devx-logs:2.1.0",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "EcsTaskDefinitionLogShippingLogGroup0E405BD0",
+                },
+                "awslogs-region": "eu-west-1",
+                "awslogs-stream-prefix": "deploy/CODE/cdk-playground/devx-logs-sidecar",
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/init",
+                "ReadOnly": false,
+                "SourceVolume": "logging-volume",
+              },
+            ],
+            "Name": "LogShipping",
+            "ReadonlyRootFilesystem": true,
+          },
+        ],
+        "Cpu": "1024",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "EcsTaskDefinitionExecutionRoleBE450C73",
+            "Arn",
+          ],
+        },
+        "Family": "CdkPlaygroundEc2CODEEcsTaskDefinition14D839E6",
+        "Memory": "2048",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "EcsTaskDefinitionTaskRoleB7B6D8DD",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Name": "logging-volume",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "EcsTaskDefinitionExecutionRoleBE450C73": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EcsTaskDefinitionExecutionRoleDefaultPolicy1611A942": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecr:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":repository/guardian/cdk-playground",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate",
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "EcsTaskDefinitionLogShippingLogGroup0E405BD0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EcsTaskDefinitionExecutionRoleDefaultPolicy1611A942",
+        "Roles": [
+          {
+            "Ref": "EcsTaskDefinitionExecutionRoleBE450C73",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "EcsTaskDefinitionLogShippingLogGroup0E405BD0": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "EcsTaskDefinitionTaskRoleB7B6D8DD": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
+        "Roles": [
+          {
+            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "GetDistributablePolicyCdkplaygroundBFB4D02B": {
       "Properties": {
         "PolicyDocument": {
@@ -360,6 +912,67 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground-ecs",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupCdkplaygroundecsfromCdkPlaygroundEc2CODELoadBalancerCdkplaygroundSecurityGroup18287D7A9000BB026B8E": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "GuHttpsEgressSecurityGroupCdkplaygroundfromCdkPlaygroundEc2CODELoadBalancerCdkplaygroundSecurityGroup18287D7A9000703932FA": {
       "Properties": {
@@ -471,8 +1084,21 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         ],
         "DefaultActions": [
           {
-            "TargetGroupArn": {
-              "Ref": "TargetGroupCdkplayground7A453FC2",
+            "ForwardConfig": {
+              "TargetGroups": [
+                {
+                  "TargetGroupArn": {
+                    "Ref": "EcsTargetGroupCdkplayground55757231",
+                  },
+                  "Weight": 0,
+                },
+                {
+                  "TargetGroupArn": {
+                    "Ref": "TargetGroupCdkplayground7A453FC2",
+                  },
+                  "Weight": 999,
+                },
+              ],
             },
             "Type": "forward",
           },
@@ -615,6 +1241,27 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundEc2CODEGuHttpsEgressSecurityGroupCdkplaygroundecsC9C5D1759000EE07DB64": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ParameterStoreReadCdkplaygroundF78958B9": {
       "Properties": {
         "PolicyDocument": {
@@ -661,6 +1308,57 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         "Roles": [
           {
             "Ref": "InstanceRoleCdkplaygroundC280027A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStoreReadCdkplaygroundecsB1E187C6": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-ecs",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/deploy/cdk-playground-ecs/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
           },
         ],
       },

--- a/cdk/lib/cdk-playground-ec2.test.ts
+++ b/cdk/lib/cdk-playground-ec2.test.ts
@@ -7,6 +7,7 @@ describe('The cdk-playground infrastructure definition', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
 			buildIdentifier: 'TEST',
+			imageIdentifier: 'sha256:12345',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/cdk-playground-ec2.ts
+++ b/cdk/lib/cdk-playground-ec2.ts
@@ -2,6 +2,8 @@ import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuStack, type GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
+import { GuEcsAppExperimental } from '@guardian/cdk/lib/experimental/patterns/ecs-app';
+import type { GuDomainName } from '@guardian/cdk/lib/types';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
@@ -15,6 +17,13 @@ interface CdkPlaygroundEc2Props extends Omit<GuStackProps, 'stack' | 'stage'> {
 	 * process.env.GITHUB_RUN_NUMBER
 	 */
 	buildIdentifier: string;
+	/**
+	 * Which image to run.
+	 * This should be the image digest (e.g. 'sha256:abc123') to ensure immutable deployments.
+	 *
+	 * @see https://docs.docker.com/dhi/core-concepts/digests
+	 */
+	imageIdentifier: string;
 }
 
 export class CdkPlaygroundEc2 extends GuStack {
@@ -26,27 +35,28 @@ export class CdkPlaygroundEc2 extends GuStack {
 			env: { region: 'eu-west-1' },
 		});
 
-		const { buildIdentifier } = props;
+		const { buildIdentifier, imageIdentifier } = props;
 
 		const ec2AppDomainName = 'cdk-playground.code.dev-gutools.co.uk';
+		const certificateProps: GuDomainName = {
+			domainName: ec2AppDomainName,
+		};
 
-		const ec2App = 'cdk-playground';
+		const app = 'cdk-playground';
 
-		const { loadBalancer } = new GuEc2AppExperimental(this, {
+		const ec2App = new GuEc2AppExperimental(this, {
 			buildIdentifier,
 			applicationPort: 9000,
-			app: ec2App,
+			app,
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
 			access: { scope: AccessScope.PUBLIC },
 			userData: {
 				distributable: {
-					fileName: `${ec2App}-${buildIdentifier}.deb`,
-					executionStatement: `dpkg -i /${ec2App}/${ec2App}-${buildIdentifier}.deb`,
+					fileName: `${app}-${buildIdentifier}.deb`,
+					executionStatement: `dpkg -i /${app}/${app}-${buildIdentifier}.deb`,
 				},
 			},
-			certificateProps: {
-				domainName: ec2AppDomainName,
-			},
+			certificateProps,
 			monitoringConfiguration: { noMonitoring: true },
 			scaling: {
 				minimumInstances: 1,
@@ -60,11 +70,32 @@ export class CdkPlaygroundEc2 extends GuStack {
 			instanceMetricGranularity: '5Minute',
 		});
 
+		new GuEcsAppExperimental(this, {
+			app,
+			applicationPort: 9000,
+			certificateProps,
+			cpu: 1024,
+			imageIdentifier,
+			memoryLimitMiB: 2048,
+			repositoryName: 'guardian/cdk-playground',
+			scaling: { minimumTasks: 1, maximumTasks: 10 },
+			// This is the important bit for the migration; it allows us to share the existing ALB & listener and split
+			// traffic between the EC2 and ECS target groups
+			migrationProps: {
+				loadBalancer: ec2App.loadBalancer,
+				listener: ec2App.listener,
+				targetGroup: ec2App.targetGroup,
+				// Although to begin with we send 0% traffic to the ECS target group; I think we need an initial deploy to
+				// get some healthy tasks before we start routing traffic to them
+				weightForEcsTargetGroup: 0,
+			},
+		});
+
 		new GuCname(this, 'EC2AppDNS', {
-			app: ec2App,
+			app: app,
 			ttl: Duration.hours(1),
 			domainName: ec2AppDomainName,
-			resourceRecord: loadBalancer.loadBalancerDnsName,
+			resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
 		});
 	}
 }

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@aws-sdk/client-auto-scaling": "3.1034.0",
 				"@aws-sdk/credential-providers": "3.1034.0",
-				"@guardian/cdk": "63.2.0",
+				"@guardian/cdk": "github:guardian/cdk#jwjb/new-ecs-pattern",
 				"@guardian/eslint-config": "14.0.1",
 				"@guardian/prettier": "10.0.0",
 				"@types/aws-lambda": "8.10.161",
@@ -79,7 +79,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -89,12 +88,26 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
@@ -326,52 +339,52 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ec2": {
-			"version": "3.1004.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1004.0.tgz",
-			"integrity": "sha512-tfNLeHKJPz+NYczwobS9IZbIbu+75ktJFRoYaNiYrk6RLLHfHIJ/pnP9uyJqAdNt3Kh7Jslw+540ZroN41IcRg==",
+			"version": "3.1045.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1045.0.tgz",
+			"integrity": "sha512-/ShpsuHZbpwiNBSRc6rupxFRh/NqKTaxAZv34w58tPFOgghpJ8vPX2VV+FZiZJWHqrdQfwk7PhStxRpOz+ru+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.18",
-				"@aws-sdk/credential-provider-node": "^3.972.18",
-				"@aws-sdk/middleware-host-header": "^3.972.7",
-				"@aws-sdk/middleware-logger": "^3.972.7",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.7",
-				"@aws-sdk/middleware-sdk-ec2": "^3.972.13",
-				"@aws-sdk/middleware-user-agent": "^3.972.19",
-				"@aws-sdk/region-config-resolver": "^3.972.7",
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-endpoints": "^3.996.4",
-				"@aws-sdk/util-user-agent-browser": "^3.972.7",
-				"@aws-sdk/util-user-agent-node": "^3.973.4",
-				"@smithy/config-resolver": "^4.4.10",
-				"@smithy/core": "^3.23.8",
-				"@smithy/fetch-http-handler": "^5.3.13",
-				"@smithy/hash-node": "^4.2.11",
-				"@smithy/invalid-dependency": "^4.2.11",
-				"@smithy/middleware-content-length": "^4.2.11",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/middleware-retry": "^4.4.39",
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/middleware-stack": "^4.2.11",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/node-http-handler": "^4.4.14",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/credential-provider-node": "^3.972.39",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-sdk-ec2": "^3.972.22",
+				"@aws-sdk/middleware-user-agent": "^3.972.38",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.24",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.17",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.7",
+				"@smithy/middleware-serde": "^4.2.20",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-body-length-browser": "^4.2.2",
 				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.38",
-				"@smithy/util-defaults-mode-node": "^4.2.41",
-				"@smithy/util-endpoints": "^3.3.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-retry": "^4.2.11",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.6",
 				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.2.11",
+				"@smithy/util-waiter": "^4.3.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -379,51 +392,51 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ssm": {
-			"version": "3.1004.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1004.0.tgz",
-			"integrity": "sha512-M0vxsZ8X2LFPNWgCS7XekM/8SUPOEnSWaMDXLoXmO/BxW8M3wV84ijXQx0x+8EcR+945ZOOWFD+9rpmGd3RX3A==",
+			"version": "3.1045.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1045.0.tgz",
+			"integrity": "sha512-cNMoUJcFb+u52rvQynNW9HrjeW9rd8iyfz8Z0TgS2aTEvc8p8s4zdBHTmaUF/SpC1GatUEqKnogGC0RkD1k8NA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.18",
-				"@aws-sdk/credential-provider-node": "^3.972.18",
-				"@aws-sdk/middleware-host-header": "^3.972.7",
-				"@aws-sdk/middleware-logger": "^3.972.7",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.7",
-				"@aws-sdk/middleware-user-agent": "^3.972.19",
-				"@aws-sdk/region-config-resolver": "^3.972.7",
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-endpoints": "^3.996.4",
-				"@aws-sdk/util-user-agent-browser": "^3.972.7",
-				"@aws-sdk/util-user-agent-node": "^3.973.4",
-				"@smithy/config-resolver": "^4.4.10",
-				"@smithy/core": "^3.23.8",
-				"@smithy/fetch-http-handler": "^5.3.13",
-				"@smithy/hash-node": "^4.2.11",
-				"@smithy/invalid-dependency": "^4.2.11",
-				"@smithy/middleware-content-length": "^4.2.11",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/middleware-retry": "^4.4.39",
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/middleware-stack": "^4.2.11",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/node-http-handler": "^4.4.14",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/credential-provider-node": "^3.972.39",
+				"@aws-sdk/middleware-host-header": "^3.972.10",
+				"@aws-sdk/middleware-logger": "^3.972.10",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
+				"@aws-sdk/middleware-user-agent": "^3.972.38",
+				"@aws-sdk/region-config-resolver": "^3.972.13",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-endpoints": "^3.996.8",
+				"@aws-sdk/util-user-agent-browser": "^3.972.10",
+				"@aws-sdk/util-user-agent-node": "^3.973.24",
+				"@smithy/config-resolver": "^4.4.17",
+				"@smithy/core": "^3.23.17",
+				"@smithy/fetch-http-handler": "^5.3.17",
+				"@smithy/hash-node": "^4.2.14",
+				"@smithy/invalid-dependency": "^4.2.14",
+				"@smithy/middleware-content-length": "^4.2.14",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.7",
+				"@smithy/middleware-serde": "^4.2.20",
+				"@smithy/middleware-stack": "^4.2.14",
+				"@smithy/node-config-provider": "^4.3.14",
+				"@smithy/node-http-handler": "^4.6.1",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
+				"@smithy/url-parser": "^4.2.14",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-body-length-browser": "^4.2.2",
 				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.38",
-				"@smithy/util-defaults-mode-node": "^4.2.41",
-				"@smithy/util-endpoints": "^3.3.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-retry": "^4.2.11",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
+				"@smithy/util-endpoints": "^3.4.2",
+				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/util-retry": "^4.3.6",
 				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.2.11",
+				"@smithy/util-waiter": "^4.3.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -431,24 +444,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.3.tgz",
-			"integrity": "sha512-W3aJJm2clu8OmsrwMOMnfof13O6LGnbknnZIQeSRbxjqKah2nVvkjbUBBZVhWrt08KC69H7WsINTdrxC/2SXQw==",
+			"version": "3.974.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+			"integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.18",
-				"@smithy/core": "^3.23.16",
+				"@aws-sdk/xml-builder": "^3.972.22",
+				"@smithy/core": "^3.23.17",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-retry": "^4.3.6",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -474,13 +487,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.29.tgz",
-			"integrity": "sha512-rf+AlUxgTeSzQ/4zoS0D+Bt7XvgpY48PnWG8Yg/N9fdMgyK2Jaqa+6tLZp4MYMIMHkGrfAxnbSeb2YLMGFMg6g==",
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+			"integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/types": "^4.14.1",
@@ -491,21 +504,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.31.tgz",
-			"integrity": "sha512-TR2/lQ3qKFj2EOrsiASzemsNEz2uzZ/SUBf48+U4Cr9a/FZlHfH/hwAeBJNBp1gMyJNxROJZhT3dn1cO+jnYfQ==",
+			"version": "3.972.36",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+			"integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/node-http-handler": "^4.6.1",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-stream": "^4.5.25",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -513,20 +526,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.33.tgz",
-			"integrity": "sha512-UwdbJbOrgnOxZbshaNZ4DzX35h5wQd33MNYTGzWhN3ORG9lG9KQbDX6l6tDJSAdaGTktJoZPSritmUoW1rYkRA==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+			"integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/credential-provider-env": "^3.972.29",
-				"@aws-sdk/credential-provider-http": "^3.972.31",
-				"@aws-sdk/credential-provider-login": "^3.972.33",
-				"@aws-sdk/credential-provider-process": "^3.972.29",
-				"@aws-sdk/credential-provider-sso": "^3.972.33",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/credential-provider-env": "^3.972.34",
+				"@aws-sdk/credential-provider-http": "^3.972.36",
+				"@aws-sdk/credential-provider-login": "^3.972.38",
+				"@aws-sdk/credential-provider-process": "^3.972.34",
+				"@aws-sdk/credential-provider-sso": "^3.972.38",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/credential-provider-imds": "^4.2.14",
 				"@smithy/property-provider": "^4.2.14",
@@ -539,14 +552,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.33.tgz",
-			"integrity": "sha512-WyZuPVoDM1HGNl41eVg8HSSXIB+FGkuuK63GhDbh4TMdfWU03AciWvF/QqOVWvJtWVYaLddANJ+aUklVr2ieuw==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+			"integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/protocol-http": "^5.3.14",
@@ -559,18 +572,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.34.tgz",
-			"integrity": "sha512-sPcisURibKU4x0PCWJkWF1KJYm49Cph9dCn/PAnG5FU0wq5Id3g2v7RuEWAtNlKv1Af4gUJYBVGOeNpSEEx41A==",
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+			"integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.29",
-				"@aws-sdk/credential-provider-http": "^3.972.31",
-				"@aws-sdk/credential-provider-ini": "^3.972.33",
-				"@aws-sdk/credential-provider-process": "^3.972.29",
-				"@aws-sdk/credential-provider-sso": "^3.972.33",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
+				"@aws-sdk/credential-provider-env": "^3.972.34",
+				"@aws-sdk/credential-provider-http": "^3.972.36",
+				"@aws-sdk/credential-provider-ini": "^3.972.38",
+				"@aws-sdk/credential-provider-process": "^3.972.34",
+				"@aws-sdk/credential-provider-sso": "^3.972.38",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/credential-provider-imds": "^4.2.14",
 				"@smithy/property-provider": "^4.2.14",
@@ -583,13 +596,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.29.tgz",
-			"integrity": "sha512-DURisqWS3bUgiwMXTmzymVNGlcRW0FnbPZ3SZknhmxnCXm3n9idkTJ6T+Uir359KRKtJNFLRViskk8HsSVLi1w==",
+			"version": "3.972.34",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+			"integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -601,15 +614,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.33.tgz",
-			"integrity": "sha512-9y9obU4IQWru9f+NiiscUeyCe5ZmQav4FKEb1qfUNrik/C3BzBGUnHQWyPEyXjOX9cb+vx1TYx0qZBtinKdzTA==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+			"integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
-				"@aws-sdk/token-providers": "3.1034.0",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
+				"@aws-sdk/token-providers": "3.1041.0",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -621,14 +634,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.33.tgz",
-			"integrity": "sha512-RazhlN0YAkna2T2p2v4YuuRlVBVRNo8V0SL+9JePTWDndEUAeOBAjYeQfAMbtDyCh120+zA0Op6V0jS4dw2+iw==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+			"integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -720,19 +733,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-ec2": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.13.tgz",
-			"integrity": "sha512-mcmO0xwjB+H68XMWBBrTD7w9fARzH7/vo7ZvJenicIGZP18tAqiETF/bDMNjtzfLbfANMBpGbn7/3lmt4dncdA==",
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.22.tgz",
+			"integrity": "sha512-i9BeGH8OIPXmDuu5VZEvq3QVzP2Upt0QJsW/0ziS873CJ+zFiCyobiqQ3QTgJpxIsBBXBswsRQajEG+PvuKxYg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-format-url": "^3.972.7",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/signature-v4": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/util-format-url": "^3.972.10",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -740,24 +753,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.32",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.32.tgz",
-			"integrity": "sha512-dc2O2x0V5pGJhmdQYQveUIFtMZsur7GrGuSgoKM4oQJuEcfvwnJ3sj+ip6WnxR5l6TrX5zkl4KgcgswOy3wAzQ==",
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+			"integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"@smithy/util-config-provider": "^4.2.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
+				"@smithy/util-stream": "^4.5.25",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -766,19 +779,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.33.tgz",
-			"integrity": "sha512-mqtT3Fo7xanWMk2SbAcKLGGI/q1GHWNrExBj7cnWP2W2mkTMheXB4ntJvwPZ1UxPrQobrsv2dWFXmaOJeSOiDg==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+			"integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-retry": "^4.3.6",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -786,49 +799,49 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.1.tgz",
-			"integrity": "sha512-Afc9hc2WZs3X4Jb8dnxyuYiZsLoWRO51roTCRf497gPnAKN2WRdXANu1vaVCTzwnDMOYFXb/cYv4ZSjxqAqcKA==",
+			"version": "3.997.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+			"integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.8",
 				"@aws-sdk/middleware-host-header": "^3.972.10",
 				"@aws-sdk/middleware-logger": "^3.972.10",
 				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.33",
+				"@aws-sdk/middleware-user-agent": "^3.972.38",
 				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.20",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.25",
 				"@aws-sdk/types": "^3.973.8",
 				"@aws-sdk/util-endpoints": "^3.996.8",
 				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.19",
+				"@aws-sdk/util-user-agent-node": "^3.973.24",
 				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.16",
+				"@smithy/core": "^3.23.17",
 				"@smithy/fetch-http-handler": "^5.3.17",
 				"@smithy/hash-node": "^4.2.14",
 				"@smithy/invalid-dependency": "^4.2.14",
 				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.31",
-				"@smithy/middleware-retry": "^4.5.4",
-				"@smithy/middleware-serde": "^4.2.19",
+				"@smithy/middleware-endpoint": "^4.4.32",
+				"@smithy/middleware-retry": "^4.5.7",
+				"@smithy/middleware-serde": "^4.2.20",
 				"@smithy/middleware-stack": "^4.2.14",
 				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.0",
+				"@smithy/node-http-handler": "^4.6.1",
 				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/smithy-client": "^4.12.13",
 				"@smithy/types": "^4.14.1",
 				"@smithy/url-parser": "^4.2.14",
 				"@smithy/util-base64": "^4.3.2",
 				"@smithy/util-body-length-browser": "^4.2.2",
 				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.48",
-				"@smithy/util-defaults-mode-node": "^4.2.53",
+				"@smithy/util-defaults-mode-browser": "^4.3.49",
+				"@smithy/util-defaults-mode-node": "^4.2.54",
 				"@smithy/util-endpoints": "^3.4.2",
 				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
+				"@smithy/util-retry": "^4.3.6",
 				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
@@ -854,13 +867,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.20.tgz",
-			"integrity": "sha512-MEj6DhEcaO8RgVtFCJ+xpCQnZC3Iesr09avdY75qkMQfckQULu447IegK7Rs1MCGerVBfKnJQ4q+pQq9hI5lng==",
+			"version": "3.996.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+			"integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.32",
+				"@aws-sdk/middleware-sdk-s3": "^3.972.37",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/protocol-http": "^5.3.14",
 				"@smithy/signature-v4": "^5.3.14",
@@ -872,14 +885,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1034.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1034.0.tgz",
-			"integrity": "sha512-8E+KGcD4ET0H9FXJ2/ZWbfFnQNYEkTZZYJxAs1lkdJlve1AYuqaydInIFfvNgoz5GbYtzbK8/ugsSMu5wPm6kA==",
+			"version": "3.1041.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+			"integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.8",
+				"@aws-sdk/nested-clients": "^3.997.6",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/property-provider": "^4.2.14",
 				"@smithy/shared-ini-file-loader": "^4.4.9",
@@ -935,15 +948,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-format-url": {
-			"version": "3.972.7",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.7.tgz",
-			"integrity": "sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA==",
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+			"integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.5",
-				"@smithy/querystring-builder": "^4.2.11",
-				"@smithy/types": "^4.13.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -976,13 +989,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.19",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.19.tgz",
-			"integrity": "sha512-ZAfHjpzdbrzkAftC139JoYGfXzDh5HY+AxRzw8pGJ8cULsf+l721sKAMK8mV5NvRETaW/BwghSwQhGgoNgrxMw==",
+			"version": "3.973.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+			"integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.33",
+				"@aws-sdk/middleware-user-agent": "^3.972.38",
 				"@aws-sdk/types": "^3.973.8",
 				"@smithy/node-config-provider": "^4.3.14",
 				"@smithy/types": "^4.14.1",
@@ -1002,14 +1015,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.19",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
-			"integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+			"integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@nodable/entities": "2.1.0",
 				"@smithy/types": "^4.14.1",
-				"fast-xml-parser": "5.7.1",
+				"fast-xml-parser": "5.7.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2239,16 +2253,15 @@
 			}
 		},
 		"node_modules/@guardian/cdk": {
-			"version": "63.2.0",
-			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-63.2.0.tgz",
-			"integrity": "sha512-f5ttVoQNOlYyAVRVMtz3T3e7f7UyiRJxaXAOl6LZ57UXRMsHn+768ogZ3zab36ujVnArD0EvbJY4jTo8CDc36A==",
+			"version": "63.3.0",
+			"resolved": "git+ssh://git@github.com/guardian/cdk.git#3eb82a8bd358cedbc84b6773452ccab3fa500ac6",
 			"dev": true,
 			"dependencies": {
-				"@aws-sdk/client-ec2": "^3.1001.0",
-				"@aws-sdk/client-ssm": "^3.1001.0",
-				"@aws-sdk/credential-providers": "^3.1001.0",
+				"@aws-sdk/client-ec2": "^3.1034.0",
+				"@aws-sdk/client-ssm": "^3.1034.0",
+				"@aws-sdk/credential-providers": "^3.1034.0",
 				"chalk": "^4.1.2",
-				"codemaker": "^1.127.0",
+				"codemaker": "^1.128.0",
 				"git-url-parse": "^16.0.1",
 				"js-yaml": "^4.1.1",
 				"read-pkg-up": "7.0.1",
@@ -3053,21 +3066,14 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.16",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-			"integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.1.tgz",
+			"integrity": "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
+				"@aws-crypto/crc32": "5.2.0",
 				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3167,19 +3173,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.31",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
-			"integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.5.1.tgz",
+			"integrity": "sha512-qtqu5TS+8Y18ZDkJoiXN5AMW1G4JAg1+xytzpsUvIR5a4EUsgd5HQg12lekEHWpm2TDUmOgg+hBaHK7dvyWdkA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
-				"@smithy/middleware-serde": "^4.2.19",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-middleware": "^4.2.14",
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3187,21 +3187,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
-			"integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.6.1.tgz",
+			"integrity": "sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/service-error-classification": "^4.3.0",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
-				"@smithy/uuid": "^1.1.2",
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3209,15 +3201,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.19",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
-			"integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.3.1.tgz",
+			"integrity": "sha512-t7YtUe076zWVypVmy1rX91oKi2TFJCkpfFpfMhJFpEIRPP0iL9JxjeSyFQ+1bF45JUfDzOzslUJa150WcSrBug==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3255,14 +3245,13 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
-			"integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.1.tgz",
+			"integrity": "sha512-BdEYko85f/ldp68uH8XEyIvo810xFk6eyPH81SRggTOApYHWA+Xu7B2EzLuHbe37WVLaUA7F1fWR3/zBeme2WA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
+				"@smithy/core": "^3.24.1",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -3327,19 +3316,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/@smithy/service-error-classification": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
-			"integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@smithy/shared-ini-file-loader": {
 			"version": "4.4.9",
 			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
@@ -3375,18 +3351,14 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.12.12",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
-			"integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.13.1.tgz",
+			"integrity": "sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.23.16",
-				"@smithy/middleware-endpoint": "^4.4.31",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
+				"@smithy/core": "^3.24.1",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.24",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3490,15 +3462,13 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.48",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
-			"integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.4.1.tgz",
+			"integrity": "sha512-1rA7w+LjK1WJClsffC81Z/ZtjFt22QsKhBjUYEnZsGVS2nOTfOENKBzdg4SxhdwFvBCjcbpjscUfXOPwE3UHWQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3506,18 +3476,13 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.53",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
-			"integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.3.1.tgz",
+			"integrity": "sha512-1fk1wfQHBenQD5NitVKOFgW0wsISYAFPIXGyStJWAeCtMyRhgHYvtJxBk2rwGWA0L5QX6oM6yeHSLKPFMk59ww==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.12",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3567,14 +3532,13 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
-			"integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.4.1.tgz",
+			"integrity": "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/service-error-classification": "^4.3.0",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3582,19 +3546,13 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.5.24",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
-			"integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.6.1.tgz",
+			"integrity": "sha512-GjZfEft0M0V3n2YM/LGkr5LeLd8gxHUIzW0rUz6VtTtlAq245GxHlJghvoPEjJHKTj255iHFAiA4IsIdK40Ueg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.0",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3629,26 +3587,13 @@
 			}
 		},
 		"node_modules/@smithy/util-waiter": {
-			"version": "4.2.16",
-			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
-			"integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.4.1.tgz",
+			"integrity": "sha512-G/gWDykZNL0NVcd1qXkoKm45jxJECp6q53DSomM5QKMsyAMEsGksVq+HwgonqYxfFJEzzHi6ljtWKXVS1pl0/Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/uuid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
+				"@smithy/core": "^3.24.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4795,7 +4740,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"jsonschema": "~1.4.1",
 				"semver": "^7.7.3"
@@ -4812,7 +4756,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -4822,7 +4765,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4834,15 +4776,13 @@
 			"version": "1.0.2",
 			"dev": true,
 			"inBundle": true,
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ajv": {
 			"version": "8.18.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4859,7 +4799,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4869,7 +4808,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -4885,7 +4823,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4895,7 +4832,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
@@ -4905,7 +4841,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
@@ -4918,7 +4853,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "(MIT OR GPL-3.0-or-later)",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -4928,7 +4862,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -4940,22 +4873,19 @@
 			"version": "1.1.4",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fast-uri": {
 			"version": "3.1.0",
@@ -4971,15 +4901,13 @@
 				}
 			],
 			"inBundle": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fs-extra": {
 			"version": "11.3.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -4993,15 +4921,13 @@
 			"version": "4.2.11",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ignore": {
 			"version": "5.3.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -5011,7 +4937,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -5020,15 +4945,13 @@
 			"version": "1.0.0",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/jsonfile": {
 			"version": "6.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -5041,7 +4964,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -5050,15 +4972,13 @@
 			"version": "4.4.2",
 			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/mime-db": {
 			"version": "1.52.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5068,7 +4988,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
@@ -5081,7 +5000,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
 			},
@@ -5097,7 +5015,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -5107,7 +5024,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5117,7 +5033,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -5130,7 +5045,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
@@ -5148,7 +5062,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -5163,7 +5076,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -5176,7 +5088,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -5193,7 +5104,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -5203,7 +5113,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">= 6"
 			}
@@ -5578,9 +5487,9 @@
 			}
 		},
 		"node_modules/codemaker": {
-			"version": "1.127.0",
-			"resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.127.0.tgz",
-			"integrity": "sha512-iX64GnNH86f88aRj/McYBSNRKT+bn21Okng0v/aGI/G66uOx7bKAf5bhGiqSaip7s5OcXfvjyJ6iA0VhLL4bSg==",
+			"version": "1.129.0",
+			"resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.129.0.tgz",
+			"integrity": "sha512-FhKBLCymc5UZNhF4bAbG+IkS++eVy+Kl8P5DUV8egArXC6uomq0VBTVOE2ARoJ5FHrNXPKoDD37BHA8DqCEzKA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -6739,9 +6648,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-			"integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+			"integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
 			"dev": true,
 			"funding": [
 				{
@@ -8591,9 +8500,9 @@
 			}
 		},
 		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10367,9 +10276,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"dev": true,
 			"funding": [
 				{

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@aws-sdk/client-auto-scaling": "3.1034.0",
 		"@aws-sdk/credential-providers": "3.1034.0",
-		"@guardian/cdk": "63.2.0",
+		"@guardian/cdk": "github:guardian/cdk#jwjb/new-ecs-pattern",
 		"@guardian/eslint-config": "14.0.1",
 		"@guardian/prettier": "10.0.0",
 		"@types/aws-lambda": "8.10.161",


### PR DESCRIPTION
The overall migration process needs to be applied in several separate deployments:

https://github.com/guardian/cdk-playground/pull/1100 - **Introduce the ECS infrastructure but don't route any traffic to it (this PR).**
https://github.com/guardian/cdk-playground/pull/1101 - Route 50% traffic to the ECS infrastructure.
https://github.com/guardian/cdk-playground/pull/1102 - Route all traffic to the ECS infrastructure.
https://github.com/guardian/cdk-playground/pull/1103 - Remove EC2 infrastructure and swap to creating the load balancer & listener via `GuEcsApp`.

Originally the load balancer and listener are created via the `GuEc2App` class. The `GuEcsApp` class modifies the listener to control the % of traffic that is sent to the EC2 and ECS target groups. In the final step, the `GuEc2App` class is removed and the `GuEcsApp` class becomes responsible for creating the load balancer and listener. From a CloudFormation perspective it doesn't matter which class is responsible for creating the load balancer. If the logical ID and properties of the resource are unchanged, then CloudFormation won't try to replace or update it.

This migration relies on https://github.com/guardian/cdk/pull/2903.

---

https://riffraff.gutools.co.uk/deployment/view/e41e3577-0bd0-463b-86a6-767c3c34f6a1

<img width="1632" height="372" alt="image" src="https://github.com/user-attachments/assets/ba26a9c7-ab20-40d1-9a1a-0497f0d95996" />

---

Note that for 'real' apps there would also be some CI changes required to build the image and wire through the `IMAGE_DIGEST`. That's not required in our case as we've already got that part working for previous experiments.