### PR TITLE
[Step 3] Proof of concept for ECS migration (GuEcsApp)

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
@@ -1090,13 +1090,13 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   "TargetGroupArn": {
                     "Ref": "EcsTargetGroupCdkplayground55757231",
                   },
-                  "Weight": 500,
+                  "Weight": 999,
                 },
                 {
                   "TargetGroupArn": {
                     "Ref": "TargetGroupCdkplayground7A453FC2",
                   },
-                  "Weight": 499,
+                  "Weight": 0,
                 },
               ],
             },

--- a/cdk/lib/cdk-playground-ec2.ts
+++ b/cdk/lib/cdk-playground-ec2.ts
@@ -85,8 +85,8 @@ export class CdkPlaygroundEc2 extends GuStack {
 				loadBalancer: ec2App.loadBalancer,
 				listener: ec2App.listener,
 				targetGroup: ec2App.targetGroup,
-				// Route ~50% of traffic to the ECS target group
-				weightForEcsTargetGroup: 500,
+				// Route 100% of traffic to the ECS target group
+				weightForEcsTargetGroup: 999,
 			},
 		});
 


### PR DESCRIPTION
The overall migration process needs to be applied in several separate deployments:

https://github.com/guardian/cdk-playground/pull/1100 - Introduce the ECS infrastructure but don't route any traffic to it.
https://github.com/guardian/cdk-playground/pull/1101 - Route 50% traffic to the ECS infrastructure.
https://github.com/guardian/cdk-playground/pull/1102 - **Route all traffic to the ECS infrastructure (this PR).**
https://github.com/guardian/cdk-playground/pull/1103 - Remove EC2 infrastructure and swap to creating the load balancer & listener via `GuEcsApp`.

Originally the load balancer and listener are created via the `GuEc2App` class. The `GuEcsApp` class modifies the listener to control the % of traffic that is sent to the EC2 and ECS target groups. In the final step, the `GuEc2App` class is removed and the `GuEcsApp` class becomes responsible for creating the load balancer and listener. From a CloudFormation perspective it doesn't matter which class is responsible for creating the load balancer. If the logical ID and properties of the resource are unchanged, then CloudFormation won't try to replace or update it.

This migration relies on https://github.com/guardian/cdk/pull/2903.

---

https://riffraff.gutools.co.uk/deployment/view/2c266136-87fd-47f7-ad0e-e4e562c89fe7

<img width="1631" height="280" alt="image" src="https://github.com/user-attachments/assets/a6d2795d-bb59-42e6-a462-29a6ac971197" />