### PR TITLE
[Step 4] Proof of concept for ECS migration (GuEcsApp)

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -11,7 +11,6 @@ const eventForwarder = new EventForwarder(app, 'EventForwarder-CODE');
 
 const ec2Stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-ec2',
-	buildIdentifier: process.env.GITHUB_RUN_NUMBER ?? 'DEV',
 	imageIdentifier: process.env.IMAGE_DIGEST ?? 'DEV',
 });
 

--- a/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
@@ -4,32 +4,19 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
 {
   "Metadata": {
     "gu:cdk:constructs": [
+      "GuEcsAppExperimental",
       "GuVpcParameter",
-      "GuSubnetListParameter",
-      "GuSubnetListParameter",
-      "GuEc2AppExperimental",
-      "GuDistributionBucketParameter",
-      "GuCertificate",
-      "GuInstanceRole",
-      "GuSsmSshPolicy",
-      "GuDescribeEC2Policy",
+      "GuParameter",
       "GuLoggingStreamNameParameter",
-      "GuLogShippingPolicy",
-      "GuGetDistributablePolicy",
+      "GuRiffRaffDeploymentIdParameterExperimental",
       "GuParameterStoreReadPolicy",
-      "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
+      "GuApplicationTargetGroup",
+      "GuSubnetListParameter",
       "GuApplicationLoadBalancer",
       "GuAccessLoggingBucketParameter",
-      "GuApplicationTargetGroup",
+      "GuCertificate",
       "GuHttpsApplicationListener",
-      "GuRiffRaffDeploymentIdParameterExperimental",
-      "GuEcsAppExperimental",
-      "GuParameter",
-      "GuParameterStoreReadPolicy",
-      "GuHttpsEgressSecurityGroup",
-      "GuApplicationTargetGroup",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -46,18 +33,9 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     },
   },
   "Parameters": {
-    "AMICdkplayground": {
-      "Description": "Amazon Machine Image ID for the app cdk-playground. Use this in conjunction with AMIgo to keep AMIs up to date.",
-      "Type": "AWS::EC2::Image::Id",
-    },
     "AccessLoggingBucket": {
       "Default": "/account/services/access-logging/bucket",
       "Description": "S3 bucket to store your access logs",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "DistributionBucketName": {
-      "Default": "/account/services/artifact.bucket",
-      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "LoggingStreamName": {
@@ -78,11 +56,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Default": "/account/vpc/primary/subnets/private",
       "Type": "AWS::SSM::Parameter::Value<List<String>>",
     },
-    "cdkplaygroundPrivateSubnets": {
-      "Default": "/account/vpc/primary/subnets/private",
-      "Description": "A list of private subnets",
-      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
-    },
     "cdkplaygroundPublicSubnets": {
       "Default": "/account/vpc/primary/subnets/public",
       "Description": "A list of public subnets",
@@ -90,136 +63,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     },
   },
   "Resources": {
-    "AsgRollingUpdatePolicy2A1DDC6F": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "cloudformation:SignalResource",
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "AWS::StackId",
-              },
-            },
-            {
-              "Action": "elasticloadbalancing:DescribeTargetHealth",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "AutoScalingGroupCdkplaygroundASGD6E49F0F": {
-      "CreationPolicy": {
-        "AutoScalingCreationPolicy": {
-          "MinSuccessfulInstancesPercent": 100,
-        },
-        "ResourceSignal": {
-          "Count": 1,
-          "Timeout": "PT3M",
-        },
-      },
-      "DependsOn": [
-        "AsgRollingUpdatePolicy2A1DDC6F",
-      ],
-      "Properties": {
-        "DesiredCapacity": "1",
-        "HealthCheckGracePeriod": 120,
-        "HealthCheckType": "ELB",
-        "LaunchTemplate": {
-          "LaunchTemplateId": {
-            "Ref": "deployCODEcdkplaygroundCA0A63B1",
-          },
-          "Version": {
-            "Fn::GetAtt": [
-              "deployCODEcdkplaygroundCA0A63B1",
-              "LatestVersionNumber",
-            ],
-          },
-        },
-        "MaxSize": "10",
-        "MetricsCollection": [
-          {
-            "Granularity": "1Minute",
-          },
-        ],
-        "MinSize": "1",
-        "Tags": [
-          {
-            "Key": "App",
-            "PropagateAtLaunch": true,
-            "Value": "cdk-playground",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "PropagateAtLaunch": true,
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "PropagateAtLaunch": true,
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "LogKinesisStreamName",
-            "PropagateAtLaunch": true,
-            "Value": {
-              "Ref": "LoggingStreamName",
-            },
-          },
-          {
-            "Key": "Stack",
-            "PropagateAtLaunch": true,
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "PropagateAtLaunch": true,
-            "Value": "CODE",
-          },
-          {
-            "Key": "SystemdUnit",
-            "PropagateAtLaunch": true,
-            "Value": "cdk-playground.service",
-          },
-        ],
-        "TargetGroupARNs": [
-          {
-            "Ref": "TargetGroupCdkplayground7A453FC2",
-          },
-        ],
-        "VPCZoneIdentifier": {
-          "Ref": "cdkplaygroundPrivateSubnets",
-        },
-      },
-      "Type": "AWS::AutoScaling::AutoScalingGroup",
-      "UpdatePolicy": {
-        "AutoScalingRollingUpdate": {
-          "MaxBatchSize": 10,
-          "MinInstancesInService": 1,
-          "MinSuccessfulInstancesPercent": 100,
-          "PauseTime": "PT3M",
-          "SuspendProcesses": [
-            "AlarmNotification",
-            "AZRebalance",
-            "HealthCheck",
-            "InstanceRefresh",
-            "ReplaceUnhealthy",
-            "ScheduledActions",
-          ],
-          "WaitOnResourceSignals": true,
-        },
-      },
-    },
     "CertificateCdkplayground47FCF7D9": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -254,32 +97,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
-    },
-    "DescribeEC2PolicyFF5F9295": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeAutoScalingGroups",
-                "ec2:DescribeTags",
-                "ec2:DescribeInstances",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "describe-ec2-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "EC2AppDNS": {
       "Properties": {
@@ -841,78 +658,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::IAM::Policy",
     },
-    "GetDistributablePolicyCdkplaygroundBFB4D02B": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {
-                      "Ref": "DistributionBucketName",
-                    },
-                    "/deploy/CODE/cdk-playground/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "GetDistributablePolicyCdkplaygroundBFB4D02B",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8": {
-      "Properties": {
-        "GroupDescription": "Allow all outbound HTTPS traffic",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound HTTPS traffic",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "cdk-playground",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490": {
       "Properties": {
         "GroupDescription": "Allow all outbound HTTPS traffic",
@@ -974,105 +719,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "GuHttpsEgressSecurityGroupCdkplaygroundfromCdkPlaygroundEc2CODELoadBalancerCdkplaygroundSecurityGroup18287D7A9000703932FA": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "GuLogShippingPolicy981BFE5A": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "kinesis:Describe*",
-                "kinesis:Put*",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:kinesis:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/",
-                    {
-                      "Ref": "LoggingStreamName",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "GuLogShippingPolicy981BFE5A",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "InstanceRoleCdkplaygroundC280027A": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ec2.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Path": "/",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "cdk-playground",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "ListenerCdkplaygroundA8D9CA6F": {
       "Properties": {
         "Certificates": [
@@ -1084,21 +730,8 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         ],
         "DefaultActions": [
           {
-            "ForwardConfig": {
-              "TargetGroups": [
-                {
-                  "TargetGroupArn": {
-                    "Ref": "EcsTargetGroupCdkplayground55757231",
-                  },
-                  "Weight": 999,
-                },
-                {
-                  "TargetGroupArn": {
-                    "Ref": "TargetGroupCdkplayground7A453FC2",
-                  },
-                  "Weight": 0,
-                },
-              ],
+            "TargetGroupArn": {
+              "Ref": "EcsTargetGroupCdkplayground55757231",
             },
             "Type": "forward",
           },
@@ -1220,27 +853,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundEc2CODEGuHttpsEgressSecurityGroupCdkplayground0BB5710F9000BBED7E0F": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerCdkplaygroundSecurityGroupAE8BCA05",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
     "LoadBalancerCdkplaygroundSecurityGrouptoCdkPlaygroundEc2CODEGuHttpsEgressSecurityGroupCdkplaygroundecsC9C5D1759000EE07DB64": {
       "Properties": {
         "Description": "Load balancer to target",
@@ -1261,57 +873,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "ParameterStoreReadCdkplaygroundF78958B9": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/deploy/cdk-playground",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/CODE/deploy/cdk-playground/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "ParameterStoreReadCdkplaygroundecsB1E187C6": {
       "Properties": {
@@ -1363,298 +924,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "SsmSshPolicy4CFC977E": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-ssh-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "TargetGroupCdkplayground7A453FC2": {
-      "Properties": {
-        "HealthCheckIntervalSeconds": 10,
-        "HealthCheckPath": "/healthcheck",
-        "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 5,
-        "HealthyThresholdCount": 5,
-        "Port": 9000,
-        "Protocol": "HTTP",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "cdk-playground",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "TargetGroupAttributes": [
-          {
-            "Key": "deregistration_delay.timeout_seconds",
-            "Value": "30",
-          },
-          {
-            "Key": "stickiness.enabled",
-            "Value": "false",
-          },
-        ],
-        "TargetType": "instance",
-        "UnhealthyThresholdCount": 2,
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-    },
-    "deployCODEcdkplaygroundCA0A63B1": {
-      "DependsOn": [
-        "InstanceRoleCdkplaygroundC280027A",
-      ],
-      "Properties": {
-        "LaunchTemplateData": {
-          "IamInstanceProfile": {
-            "Arn": {
-              "Fn::GetAtt": [
-                "deployCODEcdkplaygroundProfileF02041A0",
-                "Arn",
-              ],
-            },
-          },
-          "ImageId": {
-            "Ref": "AMICdkplayground",
-          },
-          "InstanceType": "t4g.micro",
-          "MetadataOptions": {
-            "HttpTokens": "required",
-            "InstanceMetadataTags": "enabled",
-          },
-          "Monitoring": {
-            "Enabled": false,
-          },
-          "SecurityGroupIds": [
-            {
-              "Fn::GetAtt": [
-                "GuHttpsEgressSecurityGroupCdkplaygroundAF9827C8",
-                "GroupId",
-              ],
-            },
-          ],
-          "TagSpecifications": [
-            {
-              "ResourceType": "instance",
-              "Tags": [
-                {
-                  "Key": "App",
-                  "Value": "cdk-playground",
-                },
-                {
-                  "Key": "gu:build-identifier",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:cdk:version",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:repo",
-                  "Value": "guardian/cdk-playground",
-                },
-                {
-                  "Key": "Name",
-                  "Value": "CdkPlaygroundEc2-CODE/deploy-CODE-cdk-playground",
-                },
-                {
-                  "Key": "Stack",
-                  "Value": "deploy",
-                },
-                {
-                  "Key": "Stage",
-                  "Value": "CODE",
-                },
-              ],
-            },
-            {
-              "ResourceType": "volume",
-              "Tags": [
-                {
-                  "Key": "App",
-                  "Value": "cdk-playground",
-                },
-                {
-                  "Key": "gu:build-identifier",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:cdk:version",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:repo",
-                  "Value": "guardian/cdk-playground",
-                },
-                {
-                  "Key": "Name",
-                  "Value": "CdkPlaygroundEc2-CODE/deploy-CODE-cdk-playground",
-                },
-                {
-                  "Key": "Stack",
-                  "Value": "deploy",
-                },
-                {
-                  "Key": "Stage",
-                  "Value": "CODE",
-                },
-              ],
-            },
-          ],
-          "UserData": {
-            "Fn::Base64": {
-              "Fn::Join": [
-                "",
-                [
-                  "#!/bin/bash
-function exitTrap(){
-exitCode=$?
-
-        cfn-signal --stack ",
-                  {
-                    "Ref": "AWS::StackId",
-                  },
-                  "           --resource AutoScalingGroupCdkplaygroundASGD6E49F0F           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
-        
-}
-trap exitTrap EXIT
-mkdir -p $(dirname '/cdk-playground/cdk-playground-TEST.deb')
-aws s3 cp 's3://",
-                  {
-                    "Ref": "DistributionBucketName",
-                  },
-                  "/deploy/CODE/cdk-playground/cdk-playground-TEST.deb' '/cdk-playground/cdk-playground-TEST.deb'
-dpkg -i /cdk-playground/cdk-playground-TEST.deb
-echo "Launch template last updated by Riff-Raff deployment ID: ",
-                  {
-                    "Ref": "RiffRaffDeploymentId",
-                  },
-                  ""
-# GuEc2AppExperimental Instance Health Check Start
-
-      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
-
-      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
-                  {
-                    "Ref": "TargetGroupCdkplayground7A453FC2",
-                  },
-                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
-
-      until [ "$STATE" == "\\"healthy\\"" ]; do
-        echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
-        sleep 5
-        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
-                  {
-                    "Ref": "TargetGroupCdkplayground7A453FC2",
-                  },
-                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
-      done
-
-      echo "Instance running build TEST is healthy in target group."
-      
-# GuEc2AppExperimental Instance Health Check End",
-                ],
-              ],
-            },
-          },
-        },
-        "TagSpecifications": [
-          {
-            "ResourceType": "launch-template",
-            "Tags": [
-              {
-                "Key": "App",
-                "Value": "cdk-playground",
-              },
-              {
-                "Key": "gu:build-identifier",
-                "Value": "TEST",
-              },
-              {
-                "Key": "gu:cdk:version",
-                "Value": "TEST",
-              },
-              {
-                "Key": "gu:repo",
-                "Value": "guardian/cdk-playground",
-              },
-              {
-                "Key": "Name",
-                "Value": "CdkPlaygroundEc2-CODE/deploy-CODE-cdk-playground",
-              },
-              {
-                "Key": "Stack",
-                "Value": "deploy",
-              },
-              {
-                "Key": "Stage",
-                "Value": "CODE",
-              },
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::EC2::LaunchTemplate",
-    },
-    "deployCODEcdkplaygroundProfileF02041A0": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCdkplaygroundC280027A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/cdk/lib/cdk-playground-ec2.test.ts
+++ b/cdk/lib/cdk-playground-ec2.test.ts
@@ -6,7 +6,6 @@ describe('The cdk-playground infrastructure definition', () => {
 	it('matches the snapshot for EC2', () => {
 		const app = new App({ outdir: '/tmp/cdk.out' });
 		const stack = new CdkPlaygroundEc2(app, 'CdkPlaygroundEc2-CODE', {
-			buildIdentifier: 'TEST',
 			imageIdentifier: 'sha256:12345',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();

--- a/cdk/lib/cdk-playground-ec2.ts
+++ b/cdk/lib/cdk-playground-ec2.ts
@@ -1,22 +1,11 @@
-import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuStack, type GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
-import { GuEc2AppExperimental } from '@guardian/cdk/lib/experimental/patterns/ec2-app';
 import { GuEcsAppExperimental } from '@guardian/cdk/lib/experimental/patterns/ecs-app';
 import type { GuDomainName } from '@guardian/cdk/lib/types';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
-import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 
 interface CdkPlaygroundEc2Props extends Omit<GuStackProps, 'stack' | 'stage'> {
-	/**
-	 * Which application build to run.
-	 * This will typically match the build number provided by CI.
-	 *
-	 * @example
-	 * process.env.GITHUB_RUN_NUMBER
-	 */
-	buildIdentifier: string;
 	/**
 	 * Which image to run.
 	 * This should be the image digest (e.g. 'sha256:abc123') to ensure immutable deployments.
@@ -35,7 +24,7 @@ export class CdkPlaygroundEc2 extends GuStack {
 			env: { region: 'eu-west-1' },
 		});
 
-		const { buildIdentifier, imageIdentifier } = props;
+		const { imageIdentifier } = props;
 
 		const ec2AppDomainName = 'cdk-playground.code.dev-gutools.co.uk';
 		const certificateProps: GuDomainName = {
@@ -44,33 +33,7 @@ export class CdkPlaygroundEc2 extends GuStack {
 
 		const app = 'cdk-playground';
 
-		const ec2App = new GuEc2AppExperimental(this, {
-			buildIdentifier,
-			applicationPort: 9000,
-			app,
-			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MICRO),
-			access: { scope: AccessScope.PUBLIC },
-			userData: {
-				distributable: {
-					fileName: `${app}-${buildIdentifier}.deb`,
-					executionStatement: `dpkg -i /${app}/${app}-${buildIdentifier}.deb`,
-				},
-			},
-			certificateProps,
-			monitoringConfiguration: { noMonitoring: true },
-			scaling: {
-				minimumInstances: 1,
-				maximumInstances: 10,
-			},
-			applicationLogging: {
-				enabled: true,
-				systemdUnitName: 'cdk-playground',
-			},
-			imageRecipe: 'arm64-jammy-java21-deploy-infrastructure',
-			instanceMetricGranularity: '5Minute',
-		});
-
-		new GuEcsAppExperimental(this, {
+		const ecsApp = new GuEcsAppExperimental(this, {
 			app,
 			applicationPort: 9000,
 			certificateProps,
@@ -79,22 +42,13 @@ export class CdkPlaygroundEc2 extends GuStack {
 			memoryLimitMiB: 2048,
 			repositoryName: 'guardian/cdk-playground',
 			scaling: { minimumTasks: 1, maximumTasks: 10 },
-			// This is the important bit for the migration; it allows us to share the existing ALB & listener and split
-			// traffic between the EC2 and ECS target groups
-			migrationProps: {
-				loadBalancer: ec2App.loadBalancer,
-				listener: ec2App.listener,
-				targetGroup: ec2App.targetGroup,
-				// Route 100% of traffic to the ECS target group
-				weightForEcsTargetGroup: 999,
-			},
 		});
 
 		new GuCname(this, 'EC2AppDNS', {
 			app: app,
 			ttl: Duration.hours(1),
 			domainName: ec2AppDomainName,
-			resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
+			resourceRecord: ecsApp.loadBalancer.loadBalancerDnsName,
 		});
 	}
 }


### PR DESCRIPTION
The overall migration process needs to be applied in several separate deployments:

https://github.com/guardian/cdk-playground/pull/1100 - Introduce the ECS infrastructure but don't route any traffic to it.
https://github.com/guardian/cdk-playground/pull/1101 - Route 50% traffic to the ECS infrastructure.
https://github.com/guardian/cdk-playground/pull/1102 - Route all traffic to the ECS infrastructure.
https://github.com/guardian/cdk-playground/pull/1103 - **Remove EC2 infrastructure and swap to creating the load balancer & listener via `GuEcsApp` (this PR)**.

Originally the load balancer and listener are created via the `GuEc2App` class. The `GuEcsApp` class modifies the listener to control the % of traffic that is sent to the EC2 and ECS target groups. In the final step, the `GuEc2App` class is removed and the `GuEcsApp` class becomes responsible for creating the load balancer and listener. From a CloudFormation perspective it doesn't matter which class is responsible for creating the load balancer. If the logical ID and properties of the resource are unchanged, then CloudFormation won't try to replace or update it.

This migration relies on https://github.com/guardian/cdk/pull/2903.

---

https://riffraff.gutools.co.uk/deployment/view/5c76519d-d58d-45a7-9e64-5771b3673d80 - note that `Dangerous` mode is not required as the original load balancer has been retained.

<img width="1627" height="263" alt="image" src="https://github.com/user-attachments/assets/3abe84a8-bc79-4bcd-adf7-26b1a797929b" />

---

There are a couple of other clean up steps that may be required for 'real' apps:

1. If the project does not use the auto-generation feature for `riff-raff.yaml`, it would need to be simplified manually at this point[^1]. 
2. For a real project, users might also want to remove any EC2-specific CI steps (e.g. producing the `.deb` and uploading it to Riff-Raff) at this point.

[^1]: It's been simplified automatically in this case; we no longer need the `asg-upload-eu-west-1-deploy-cdk-playground` deployment that was used for uploading the `.deb` to S3.