### PR TITLE
[Step 4] Proof of concept for ECS migration (GuLoadBalancedApp)

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
@@ -1075,13 +1075,13 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   "TargetGroupArn": {
                     "Ref": "TargetGroupCdkplayground7A453FC2",
                   },
-                  "Weight": 500,
+                  "Weight": 0,
                 },
                 {
                   "TargetGroupArn": {
                     "Ref": "EcsTargetGroupCdkplayground55757231",
                   },
-                  "Weight": 499,
+                  "Weight": 999,
                 },
               ],
             },

--- a/cdk/lib/cdk-playground-ec2.ts
+++ b/cdk/lib/cdk-playground-ec2.ts
@@ -66,8 +66,8 @@ export class CdkPlaygroundEc2 extends GuStack {
 				scaling: { minimumTasks: 1, maximumTasks: 10 },
 			},
 			targetGroupWeights: {
-				ec2: 500,
-				ecs: 499,
+				ec2: 0,
+				ecs: 999,
 			},
 		});
 


### PR DESCRIPTION
The overall migration process needs to be applied in several separate deployments:

1. https://github.com/guardian/cdk-playground/pull/1104 - Refactor to use new `GuLoadBalancedApp` pattern instead of `GuEc2App` (this is a `cdk` change only, the snapshot only includes metadata changes). 
2. https://github.com/guardian/cdk-playground/pull/1105 - Introduce the ECS infrastructure but don't route any traffic to it.
3. https://github.com/guardian/cdk-playground/pull/1106 - Route 50% traffic to the ECS infrastructure.
4. https://github.com/guardian/cdk-playground/pull/1107 - Route all traffic to the ECS infrastructure.
5. https://github.com/guardian/cdk-playground/pull/1108 - Remove EC2 infrastructure.

Steps 1 and 2 could be combined if desired, but this split makes it a bit easier to see which code changes affect the underlying infrastructure. Steps 4 and 5 could also be combined, but I think it's pretty likely that we'll want to retain the option of quickly rolling back to EC2 for a while in most cases.

This migration relies on https://github.com/guardian/cdk/pull/2904.

---

https://riffraff.gutools.co.uk/deployment/view/30f11a89-4c08-4a0a-81e3-957c1438326e

<img width="1632" height="355" alt="image" src="https://github.com/user-attachments/assets/ee17d1a5-60b1-4223-9c86-49d2b82bfd08" />