### PR TITLE
chore(deps): Update GuCDK from 63.2.0 to 63.3.1

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ec2.test.ts.snap
@@ -161,7 +161,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "PropagateAtLaunch": true,
             "Value": "devx::cdk-playground",
           },
@@ -234,7 +234,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -356,7 +356,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -462,7 +462,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -559,7 +559,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -601,7 +601,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -750,7 +750,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -834,7 +834,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   "Value": "guardian/cdk-playground",
                 },
                 {
-                  "Key": "gu:riff-raff-project",
+                  "Key": "gu:riff-raff:project",
                   "Value": "devx::cdk-playground",
                 },
                 {
@@ -871,7 +871,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                   "Value": "guardian/cdk-playground",
                 },
                 {
-                  "Key": "gu:riff-raff-project",
+                  "Key": "gu:riff-raff:project",
                   "Value": "devx::cdk-playground",
                 },
                 {
@@ -968,7 +968,7 @@ echo "Launch template last updated by Riff-Raff deployment ID: ",
                 "Value": "guardian/cdk-playground",
               },
               {
-                "Key": "gu:riff-raff-project",
+                "Key": "gu:riff-raff:project",
                 "Value": "devx::cdk-playground",
               },
               {

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -80,7 +80,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -113,7 +113,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -210,7 +210,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -299,7 +299,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -447,7 +447,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -497,7 +497,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -593,7 +593,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -633,7 +633,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -716,7 +716,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -837,7 +837,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -879,7 +879,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {

--- a/cdk/lib/__snapshots__/cdk-playground-lambda.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-lambda.test.ts.snap
@@ -61,7 +61,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -144,7 +144,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -202,7 +202,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -327,7 +327,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -510,7 +510,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -526,7 +526,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "lambdacdkplaygroundlambdaapiDeployment157471B2fe4f0cb0700525e097b6f84513cf7205": {
+    "lambdacdkplaygroundlambdaapiDeployment157471B29fc88a7abed222ac5859e9e43263f72d": {
       "DependsOn": [
         "lambdacdkplaygroundlambdaapiproxyANYDB984CB2",
         "lambdacdkplaygroundlambdaapiproxyFA4DE6D2",
@@ -549,7 +549,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "lambdacdkplaygroundlambdaapiDeployment157471B2fe4f0cb0700525e097b6f84513cf7205",
+          "Ref": "lambdacdkplaygroundlambdaapiDeployment157471B29fc88a7abed222ac5859e9e43263f72d",
         },
         "RestApiId": {
           "Ref": "lambdacdkplaygroundlambdaapi061BB942",
@@ -569,7 +569,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -609,7 +609,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for L
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {

--- a/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
+++ b/cdk/lib/__snapshots__/event-forwarder.test.ts.snap
@@ -65,7 +65,7 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -153,7 +153,7 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -224,7 +224,7 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {
@@ -282,7 +282,7 @@ exports[`The EventForwarder stack matches the snapshot for CODE 1`] = `
             "Value": "guardian/cdk-playground",
           },
           {
-            "Key": "gu:riff-raff-project",
+            "Key": "gu:riff-raff:project",
             "Value": "devx::cdk-playground",
           },
           {

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@aws-sdk/client-auto-scaling": "3.1034.0",
 				"@aws-sdk/credential-providers": "3.1034.0",
-				"@guardian/cdk": "63.2.0",
+				"@guardian/cdk": "63.3.1",
 				"@guardian/eslint-config": "14.0.1",
 				"@guardian/prettier": "10.0.0",
 				"@types/aws-lambda": "8.10.161",
@@ -76,25 +76,36 @@
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
 			"version": "1.4.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
 			"version": "7.7.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
@@ -326,52 +337,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ec2": {
-			"version": "3.1004.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1004.0.tgz",
-			"integrity": "sha512-tfNLeHKJPz+NYczwobS9IZbIbu+75ktJFRoYaNiYrk6RLLHfHIJ/pnP9uyJqAdNt3Kh7Jslw+540ZroN41IcRg==",
+			"version": "3.1050.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.1050.0.tgz",
+			"integrity": "sha512-pJrYSya1WQs+2Wvvz8oC9bezZmbdOCFhRG39e1NIxyhAoMsHk2GQ7Yp0sKqjjn7IXKvaGAekIhdh+s3NTfK9Qg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.18",
-				"@aws-sdk/credential-provider-node": "^3.972.18",
-				"@aws-sdk/middleware-host-header": "^3.972.7",
-				"@aws-sdk/middleware-logger": "^3.972.7",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.7",
-				"@aws-sdk/middleware-sdk-ec2": "^3.972.13",
-				"@aws-sdk/middleware-user-agent": "^3.972.19",
-				"@aws-sdk/region-config-resolver": "^3.972.7",
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-endpoints": "^3.996.4",
-				"@aws-sdk/util-user-agent-browser": "^3.972.7",
-				"@aws-sdk/util-user-agent-node": "^3.973.4",
-				"@smithy/config-resolver": "^4.4.10",
-				"@smithy/core": "^3.23.8",
-				"@smithy/fetch-http-handler": "^5.3.13",
-				"@smithy/hash-node": "^4.2.11",
-				"@smithy/invalid-dependency": "^4.2.11",
-				"@smithy/middleware-content-length": "^4.2.11",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/middleware-retry": "^4.4.39",
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/middleware-stack": "^4.2.11",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/node-http-handler": "^4.4.14",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.38",
-				"@smithy/util-defaults-mode-node": "^4.2.41",
-				"@smithy/util-endpoints": "^3.3.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-retry": "^4.2.11",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.2.11",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/credential-provider-node": "^3.972.43",
+				"@aws-sdk/middleware-sdk-ec2": "^3.972.26",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -379,51 +360,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-ssm": {
-			"version": "3.1004.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1004.0.tgz",
-			"integrity": "sha512-M0vxsZ8X2LFPNWgCS7XekM/8SUPOEnSWaMDXLoXmO/BxW8M3wV84ijXQx0x+8EcR+945ZOOWFD+9rpmGd3RX3A==",
+			"version": "3.1050.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1050.0.tgz",
+			"integrity": "sha512-ZYo51WgVwAf2REtQv9M8U7E+j3oG7pmuxNkAQLFcieUVLnsDchCUyCnQ2N8GKWxZ5ckbSOHOm5fGds5Z13Lbjw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.973.18",
-				"@aws-sdk/credential-provider-node": "^3.972.18",
-				"@aws-sdk/middleware-host-header": "^3.972.7",
-				"@aws-sdk/middleware-logger": "^3.972.7",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.7",
-				"@aws-sdk/middleware-user-agent": "^3.972.19",
-				"@aws-sdk/region-config-resolver": "^3.972.7",
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-endpoints": "^3.996.4",
-				"@aws-sdk/util-user-agent-browser": "^3.972.7",
-				"@aws-sdk/util-user-agent-node": "^3.973.4",
-				"@smithy/config-resolver": "^4.4.10",
-				"@smithy/core": "^3.23.8",
-				"@smithy/fetch-http-handler": "^5.3.13",
-				"@smithy/hash-node": "^4.2.11",
-				"@smithy/invalid-dependency": "^4.2.11",
-				"@smithy/middleware-content-length": "^4.2.11",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/middleware-retry": "^4.4.39",
-				"@smithy/middleware-serde": "^4.2.12",
-				"@smithy/middleware-stack": "^4.2.11",
-				"@smithy/node-config-provider": "^4.3.11",
-				"@smithy/node-http-handler": "^4.4.14",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
-				"@smithy/url-parser": "^4.2.11",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.38",
-				"@smithy/util-defaults-mode-node": "^4.2.41",
-				"@smithy/util-endpoints": "^3.3.2",
-				"@smithy/util-middleware": "^4.2.11",
-				"@smithy/util-retry": "^4.2.11",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/util-waiter": "^4.2.11",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/credential-provider-node": "^3.972.43",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -431,25 +382,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.3.tgz",
-			"integrity": "sha512-W3aJJm2clu8OmsrwMOMnfof13O6LGnbknnZIQeSRbxjqKah2nVvkjbUBBZVhWrt08KC69H7WsINTdrxC/2SXQw==",
+			"version": "3.974.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+			"integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.18",
-				"@smithy/core": "^3.23.16",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
-				"@smithy/util-utf8": "^4.2.2",
+				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -474,15 +419,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.29.tgz",
-			"integrity": "sha512-rf+AlUxgTeSzQ/4zoS0D+Bt7XvgpY48PnWG8Yg/N9fdMgyK2Jaqa+6tLZp4MYMIMHkGrfAxnbSeb2YLMGFMg6g==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+			"integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.12",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -491,21 +436,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.31",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.31.tgz",
-			"integrity": "sha512-TR2/lQ3qKFj2EOrsiASzemsNEz2uzZ/SUBf48+U4Cr9a/FZlHfH/hwAeBJNBp1gMyJNxROJZhT3dn1cO+jnYfQ==",
+			"version": "3.972.40",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+			"integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.12",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.0",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.24",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -513,24 +455,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.33.tgz",
-			"integrity": "sha512-UwdbJbOrgnOxZbshaNZ4DzX35h5wQd33MNYTGzWhN3ORG9lG9KQbDX6l6tDJSAdaGTktJoZPSritmUoW1rYkRA==",
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+			"integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/credential-provider-env": "^3.972.29",
-				"@aws-sdk/credential-provider-http": "^3.972.31",
-				"@aws-sdk/credential-provider-login": "^3.972.33",
-				"@aws-sdk/credential-provider-process": "^3.972.29",
-				"@aws-sdk/credential-provider-sso": "^3.972.33",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/credential-provider-env": "^3.972.38",
+				"@aws-sdk/credential-provider-http": "^3.972.40",
+				"@aws-sdk/credential-provider-login": "^3.972.42",
+				"@aws-sdk/credential-provider-process": "^3.972.38",
+				"@aws-sdk/credential-provider-sso": "^3.972.42",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.42",
+				"@aws-sdk/nested-clients": "^3.997.10",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -539,18 +480,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.33.tgz",
-			"integrity": "sha512-WyZuPVoDM1HGNl41eVg8HSSXIB+FGkuuK63GhDbh4TMdfWU03AciWvF/QqOVWvJtWVYaLddANJ+aUklVr2ieuw==",
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+			"integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/nested-clients": "^3.997.10",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -559,22 +498,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.34.tgz",
-			"integrity": "sha512-sPcisURibKU4x0PCWJkWF1KJYm49Cph9dCn/PAnG5FU0wq5Id3g2v7RuEWAtNlKv1Af4gUJYBVGOeNpSEEx41A==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+			"integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.29",
-				"@aws-sdk/credential-provider-http": "^3.972.31",
-				"@aws-sdk/credential-provider-ini": "^3.972.33",
-				"@aws-sdk/credential-provider-process": "^3.972.29",
-				"@aws-sdk/credential-provider-sso": "^3.972.33",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.33",
+				"@aws-sdk/credential-provider-env": "^3.972.38",
+				"@aws-sdk/credential-provider-http": "^3.972.40",
+				"@aws-sdk/credential-provider-ini": "^3.972.42",
+				"@aws-sdk/credential-provider-process": "^3.972.38",
+				"@aws-sdk/credential-provider-sso": "^3.972.42",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.42",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -583,16 +521,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.29",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.29.tgz",
-			"integrity": "sha512-DURisqWS3bUgiwMXTmzymVNGlcRW0FnbPZ3SZknhmxnCXm3n9idkTJ6T+Uir359KRKtJNFLRViskk8HsSVLi1w==",
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+			"integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.12",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -601,18 +538,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.33.tgz",
-			"integrity": "sha512-9y9obU4IQWru9f+NiiscUeyCe5ZmQav4FKEb1qfUNrik/C3BzBGUnHQWyPEyXjOX9cb+vx1TYx0qZBtinKdzTA==",
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+			"integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
-				"@aws-sdk/token-providers": "3.1034.0",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/nested-clients": "^3.997.10",
+				"@aws-sdk/token-providers": "3.1049.0",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -621,17 +557,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.33",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.33.tgz",
-			"integrity": "sha512-RazhlN0YAkna2T2p2v4YuuRlVBVRNo8V0SL+9JePTWDndEUAeOBAjYeQfAMbtDyCh120+zA0Op6V0jS4dw2+iw==",
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+			"integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/nested-clients": "^3.997.10",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -720,45 +655,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-ec2": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.13.tgz",
-			"integrity": "sha512-mcmO0xwjB+H68XMWBBrTD7w9fARzH7/vo7ZvJenicIGZP18tAqiETF/bDMNjtzfLbfANMBpGbn7/3lmt4dncdA==",
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.972.26.tgz",
+			"integrity": "sha512-sHc/vgigKtDZa1D19Go9jQT/IjMACinFnwg7I+vmhdie3rPFjB5VF57T9cDgcG0TAQnhBTkXSm1w4+ZlKR0bEA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.5",
-				"@aws-sdk/util-format-url": "^3.972.7",
-				"@smithy/middleware-endpoint": "^4.4.22",
-				"@smithy/protocol-http": "^5.3.11",
-				"@smithy/signature-v4": "^5.3.11",
-				"@smithy/smithy-client": "^4.12.2",
-				"@smithy/types": "^4.13.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.32",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.32.tgz",
-			"integrity": "sha512-dc2O2x0V5pGJhmdQYQveUIFtMZsur7GrGuSgoKM4oQJuEcfvwnJ3sj+ip6WnxR5l6TrX5zkl4KgcgswOy3wAzQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
+				"@aws-sdk/core": "^3.974.12",
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/core": "^3.23.16",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
 				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
-				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -786,50 +693,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.1",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.1.tgz",
-			"integrity": "sha512-Afc9hc2WZs3X4Jb8dnxyuYiZsLoWRO51roTCRf497gPnAKN2WRdXANu1vaVCTzwnDMOYFXb/cYv4ZSjxqAqcKA==",
+			"version": "3.997.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+			"integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.33",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.20",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.19",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.16",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.31",
-				"@smithy/middleware-retry": "^4.5.4",
-				"@smithy/middleware-serde": "^4.2.19",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.0",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.12",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
 				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.48",
-				"@smithy/util-defaults-mode-node": "^4.2.53",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.3",
-				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -854,16 +732,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.20",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.20.tgz",
-			"integrity": "sha512-MEj6DhEcaO8RgVtFCJ+xpCQnZC3Iesr09avdY75qkMQfckQULu447IegK7Rs1MCGerVBfKnJQ4q+pQq9hI5lng==",
+			"version": "3.996.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.32",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -872,17 +749,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1034.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1034.0.tgz",
-			"integrity": "sha512-8E+KGcD4ET0H9FXJ2/ZWbfFnQNYEkTZZYJxAs1lkdJlve1AYuqaydInIFfvNgoz5GbYtzbK8/ugsSMu5wPm6kA==",
+			"version": "3.1049.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+			"integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.3",
-				"@aws-sdk/nested-clients": "^3.997.1",
+				"@aws-sdk/core": "^3.974.12",
+				"@aws-sdk/nested-clients": "^3.997.10",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -904,19 +780,6 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-arn-parser": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
 		"node_modules/@aws-sdk/util-endpoints": {
 			"version": "3.996.8",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
@@ -928,22 +791,6 @@
 				"@smithy/types": "^4.14.1",
 				"@smithy/url-parser": "^4.2.14",
 				"@smithy/util-endpoints": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-format-url": {
-			"version": "3.972.7",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.7.tgz",
-			"integrity": "sha512-V+PbnWfUl93GuFwsOHsAq7hY/fnm9kElRqR8IexIJr5Rvif9e614X5sGSyz3mVSf1YAZ+VTy63W1/pGdA55zyA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.5",
-				"@smithy/querystring-builder": "^4.2.11",
-				"@smithy/types": "^4.13.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1002,14 +849,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.19",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
-			"integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@nodable/entities": "2.1.0",
 				"@smithy/types": "^4.14.1",
-				"fast-xml-parser": "5.7.1",
+				"fast-xml-parser": "5.7.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2239,16 +2087,16 @@
 			}
 		},
 		"node_modules/@guardian/cdk": {
-			"version": "63.2.0",
-			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-63.2.0.tgz",
-			"integrity": "sha512-f5ttVoQNOlYyAVRVMtz3T3e7f7UyiRJxaXAOl6LZ57UXRMsHn+768ogZ3zab36ujVnArD0EvbJY4jTo8CDc36A==",
+			"version": "63.3.1",
+			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-63.3.1.tgz",
+			"integrity": "sha512-PdHQyhTuE9pIIIGfyQeGhwBUCI0TfpoFLCrYqdIniNA+cZWRivm+o6A8D4dxy+n9L5axFAv8YFNyUeH0BmbRGQ==",
 			"dev": true,
 			"dependencies": {
-				"@aws-sdk/client-ec2": "^3.1001.0",
-				"@aws-sdk/client-ssm": "^3.1001.0",
-				"@aws-sdk/credential-providers": "^3.1001.0",
+				"@aws-sdk/client-ec2": "^3.1034.0",
+				"@aws-sdk/client-ssm": "^3.1034.0",
+				"@aws-sdk/credential-providers": "^3.1034.0",
 				"chalk": "^4.1.2",
-				"codemaker": "^1.127.0",
+				"codemaker": "^1.128.0",
 				"git-url-parse": "^16.0.1",
 				"js-yaml": "^4.1.1",
 				"read-pkg-up": "7.0.1",
@@ -3053,21 +2901,14 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.16",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
-			"integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.24",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3075,16 +2916,14 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3092,16 +2931,14 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.17",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3255,15 +3092,14 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
-			"integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3292,21 +3128,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-uri-escape": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3355,19 +3176,14 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -3394,9 +3210,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.14.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3595,19 +3411,6 @@
 				"@smithy/util-buffer-from": "^4.2.2",
 				"@smithy/util-hex-encoding": "^4.2.2",
 				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4792,10 +4595,8 @@
 				"jsonschema",
 				"semver"
 			],
-			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"jsonschema": "~1.4.1",
 				"semver": "^7.7.3"
@@ -4809,20 +4610,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
 			"version": "1.4.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
 			"version": "7.7.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4832,17 +4629,13 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
 			"version": "1.0.2",
-			"dev": true,
 			"inBundle": true,
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ajv": {
 			"version": "8.18.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4856,20 +4649,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -4882,30 +4671,24 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/astral-regex": {
 			"version": "2.0.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/balanced-match": {
 			"version": "4.0.4",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/brace-expansion": {
 			"version": "5.0.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
@@ -4915,20 +4698,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/case": {
 			"version": "1.6.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "(MIT OR GPL-3.0-or-later)",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/color-convert": {
 			"version": "2.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -4938,28 +4717,21 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/color-name": {
 			"version": "1.1.4",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fast-uri": {
 			"version": "3.1.0",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4971,15 +4743,12 @@
 				}
 			],
 			"inBundle": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/aws-cdk-lib/node_modules/fs-extra": {
 			"version": "11.3.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -4991,44 +4760,34 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/graceful-fs": {
 			"version": "4.2.11",
-			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/aws-cdk-lib/node_modules/ignore": {
 			"version": "5.3.2",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/jsonfile": {
 			"version": "6.2.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -5038,37 +4797,29 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/jsonschema": {
 			"version": "1.5.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
 			"version": "4.4.2",
-			"dev": true,
 			"inBundle": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/aws-cdk-lib/node_modules/mime-db": {
 			"version": "1.52.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/mime-types": {
 			"version": "2.1.35",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
@@ -5078,10 +4829,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/minimatch": {
 			"version": "10.2.4",
-			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
 			},
@@ -5094,30 +4843,24 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/punycode": {
 			"version": "2.3.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/require-from-string": {
 			"version": "2.0.2",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/semver": {
 			"version": "7.7.4",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -5127,10 +4870,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/slice-ansi": {
 			"version": "4.0.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
@@ -5145,10 +4886,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/string-width": {
 			"version": "4.2.3",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -5160,10 +4899,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -5173,10 +4910,8 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/table": {
 			"version": "6.9.0",
-			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.1",
 				"lodash.truncate": "^4.4.2",
@@ -5190,20 +4925,16 @@
 		},
 		"node_modules/aws-cdk-lib/node_modules/universalify": {
 			"version": "2.0.1",
-			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/yaml": {
 			"version": "1.10.2",
-			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
-			"peer": true,
 			"engines": {
 				"node": ">= 6"
 			}
@@ -5578,9 +5309,9 @@
 			}
 		},
 		"node_modules/codemaker": {
-			"version": "1.127.0",
-			"resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.127.0.tgz",
-			"integrity": "sha512-iX64GnNH86f88aRj/McYBSNRKT+bn21Okng0v/aGI/G66uOx7bKAf5bhGiqSaip7s5OcXfvjyJ6iA0VhLL4bSg==",
+			"version": "1.131.0",
+			"resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.131.0.tgz",
+			"integrity": "sha512-C2anrL4nO7zTY2VH3ZfTzJiiHJjqSVLDlShuzssDohdcpAatEvlxhhmw2QFnOJmqfdna1fQ5Khp6dbZrP+mdRA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -6739,9 +6470,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-			"integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6752,7 +6483,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.1.5",
+				"fast-xml-builder": "^1.1.7",
 				"path-expression-matcher": "^1.5.0",
 				"strnum": "^2.2.3"
 			},
@@ -8591,9 +8322,9 @@
 			}
 		},
 		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10367,9 +10098,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"dev": true,
 			"funding": [
 				{

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@aws-sdk/client-auto-scaling": "3.1034.0",
 		"@aws-sdk/credential-providers": "3.1034.0",
-		"@guardian/cdk": "63.2.0",
+		"@guardian/cdk": "63.3.1",
 		"@guardian/eslint-config": "14.0.1",
 		"@guardian/prettier": "10.0.0",
 		"@types/aws-lambda": "8.10.161",


### PR DESCRIPTION
## What does this change?
Updates to the latest version of GuCDK. This version includes a tagging fix. See https://github.com/guardian/cdk/pull/2906.