### PR TITLE
Update lockfile

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -9649,9 +9649,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {


### PR DESCRIPTION
Builds of `main` are failing with the following error ([example](https://github.com/guardian/cdk-playground/actions/runs/26399151584/job/77707046906)):

```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error
npm error Invalid: lock file's semver@7.7.4 does not satisfy semver@7.8.1
```

I've updated the lock file locally to fix this.

---

The problem seems to have been introduced by https://github.com/guardian/cdk-playground/pull/1113. It looks like that was [automatically merged](https://github.com/guardian/cdk-playground/pull/1113#event-25755343649) even though [CI didn't run correctly](https://github.com/guardian/cdk-playground/actions/runs/26160685319).

I think this must be happening because the ['CI' job](https://github.com/guardian/cdk-playground/blob/320bf032091636c83770141ee304d712613ef6ba/.github/workflows/ci.yaml#L73-L121) (in the ['CI' workflow](https://github.com/guardian/cdk-playground/blob/320bf032091636c83770141ee304d712613ef6ba/.github/workflows/ci.yaml#L1)) was skipped:

<img width="841" height="406" alt="image" src="https://github.com/user-attachments/assets/99df289b-c28a-4262-b53e-85672580d81d" />

<img width="1920" height="845" alt="image" src="https://github.com/user-attachments/assets/f83b0e48-8a19-4dde-aedc-1199fafa4fc8" />

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks

> A job that is skipped will report its status as "Success". It will not prevent a pull request from merging, even if it is a required check.