### PR TITLE
Add lifecycle tag to facilitate clean up for images with tags in the …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ lazy val root = (project in file("."))
     dockerAliases := Seq(
       "sha"    -> env("COMMIT_SHA").getOrElse("dev"),
       "build"  -> env("BUILD_NUMBER").getOrElse("dev"),
-      "branch" -> env("BRANCH_NAME").getOrElse("dev")
+      "branch" -> env("BRANCH_NAME").getOrElse("dev"),
+      "lifecycle" -> s"${env("BRANCH_NAME").getOrElse("dev")}-${env("BUILD_NUMBER").getOrElse("dev")}",
     ).map { case (prefix, value) =>
       DockerAlias(
         name = name.value,


### PR DESCRIPTION
## What does this change?

Add lifecycle tag to facilitate clean up for images with tags in the lifecycle rules.

Lifecycle rules based on tagging proved more difficult than we thought at first, because the branch tags are unique and will be moved to the latest image.



