### PR TITLE
Specify image digest for devx-logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 logs
 lambda/cdk-playground-lambda.zip
 dist/
+.idea

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -402,7 +402,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "FirelensConfiguration": {
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:2.1.0",
+            "Image": "ghcr.io/guardian/devx-logs@sha256:cf91724a5166f1c143e07958820aa2122afb61c164b68555d15cb92abb5acda0",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -422,6 +422,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             ],
             "Name": "LogShipping",
             "ReadonlyRootFilesystem": true,
+            "VersionConsistency": "disabled",
           },
         ],
         "Cpu": "1024",

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -287,7 +287,9 @@ export class CdkPlaygroundEcs extends GuStack {
 
 		const logRouter = taskDefinition.addFirelensLogRouter('LogShipping', {
 			// See https://github.com/guardian/devx-logs
-			image: ContainerImage.fromRegistry('ghcr.io/guardian/devx-logs:2.1.0'),
+			image: ContainerImage.fromRegistry(
+				'ghcr.io/guardian/devx-logs@sha256:cf91724a5166f1c143e07958820aa2122afb61c164b68555d15cb92abb5acda0',
+			),
 
 			// Required by https://github.com/guardian/devx-logs
 			environment: {
@@ -297,6 +299,8 @@ export class CdkPlaygroundEcs extends GuStack {
 				GU_REPO: repositoryName,
 				TASK_NAME: ecsApp,
 			},
+
+			versionConsistency: VersionConsistency.DISABLED,
 
 			// Send this container's logs to CloudWatch logs, retained for 1 day
 			logging: LogDriver.awsLogs({

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"build": "tsc",
 		"test": "jest",
+    "test-update": "jest --updateSnapshot",
 		"format": "prettier --write \"{lib,bin}/**/*.ts\"",
 		"lint": "eslint lib/** bin/** --no-error-on-unmatched-pattern",
 		"synth": "cdk synth --path-metadata false --version-reporting false",


### PR DESCRIPTION
## What does this change?

Specify image digest for devx-logs and set VersionConsistency.DISABLED

## How has this change been tested?

We have deployed main and saw to not all taks were tackled at once which we expected to be the case once deployed this feature branch and so it proved.

We also checked that logging came through at all times, but especially after we deployed this branch. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214740486850834