### PR TITLE
feat: Provision CDK Playground ECS into the Playground account 

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -35,3 +35,12 @@ new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.
 ec2Stack.addDependency(eventForwarder);
+
+new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE-playground', {
+	cloudFormationStackName: 'playground-CODE-cdk-playground-ecs',
+	imageIdentifier: process.env.IMAGE_DIGEST ?? 'DEV',
+	riffRaffProjectName,
+	stack: 'playground',
+	stage: 'CODE',
+	domainName: 'cdk-playground-ecs-playground.code.dev-gutools.co.uk',
+});

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -28,6 +28,9 @@ new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 	cloudFormationStackName: 'deploy-CODE-cdk-playground-ecs',
 	imageIdentifier: process.env.IMAGE_DIGEST ?? 'DEV',
 	riffRaffProjectName,
+	stack: 'deploy',
+	stage: 'CODE',
+	domainName: 'cdk-playground-ecs.code.dev-gutools.co.uk',
 });
 
 // Configure Riff-Raff to deploy the application stack after the EventForwarder stack has finished.

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -37,6 +37,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Description": "S3 bucket to store your access logs",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "DeployToolsAccountIdParameter": {
+      "Default": "/organisation/accounts/deployTools",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "LoggingStreamName": {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
@@ -344,7 +348,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                 "",
                 [
                   {
-                    "Ref": "AWS::AccountId",
+                    "Ref": "DeployToolsAccountIdParameter",
                   },
                   ".dkr.ecr.eu-west-1.",
                   {
@@ -534,7 +538,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                     },
                     ":ecr:eu-west-1:",
                     {
-                      "Ref": "AWS::AccountId",
+                      "Ref": "DeployToolsAccountIdParameter",
                     },
                     ":repository/guardian/cdk-playground",
                   ],

--- a/cdk/lib/cdk-playground-ecs.test.ts
+++ b/cdk/lib/cdk-playground-ecs.test.ts
@@ -8,6 +8,9 @@ describe('The cdk-playground infrastructure definition', () => {
 		const stack = new CdkPlaygroundEcs(app, 'CdkPlaygroundEcs-CODE', {
 			imageIdentifier: 'sha256:12345',
 			riffRaffProjectName: 'devx::cdk-playground',
+			stack: 'deploy',
+			stage: 'CODE',
+			domainName: 'cdk-playground-ecs.code.dev-gutools.co.uk',
 		});
 		expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
 	});

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -58,7 +58,7 @@ class GuRiffRaffDeploymentIdParameter extends CfnParameter {
 	}
 }
 
-interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
+interface CdkPlaygroundEcsProps extends GuStackProps {
 	/**
 	 * Which image to run.
 	 * This should be the image digest (e.g. 'sha256:abc123') to ensure immutable deployments.
@@ -66,6 +66,8 @@ interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	 * @see https://docs.docker.com/dhi/core-concepts/digests
 	 */
 	imageIdentifier: string;
+
+	domainName: string;
 }
 
 // For now, we provision all of this infrastructure via constructs as part of this repo.
@@ -74,8 +76,6 @@ export class CdkPlaygroundEcs extends GuStack {
 	constructor(scope: App, id: string, props: CdkPlaygroundEcsProps) {
 		super(scope, id, {
 			...props,
-			stack: 'deploy',
-			stage: 'CODE',
 			env: { region: 'eu-west-1' },
 		});
 
@@ -86,9 +86,8 @@ export class CdkPlaygroundEcs extends GuStack {
 			region,
 		} = this;
 
-		const { imageIdentifier } = props;
+		const { imageIdentifier, domainName } = props;
 		const ecsApp = 'cdk-playground-ecs';
-		const ecsDomainName = 'cdk-playground-ecs.code.dev-gutools.co.uk';
 
 		const vpc = GuVpc.fromIdParameter(this, 'GuVpc');
 
@@ -270,7 +269,7 @@ export class CdkPlaygroundEcs extends GuStack {
 			loadBalancer,
 			certificate: new GuCertificate(this, {
 				app: ecsApp,
-				domainName: ecsDomainName,
+				domainName,
 			}),
 			targetGroup,
 			// When open=true, AWS will create a security group which allows all inbound traffic over HTTPS
@@ -281,7 +280,7 @@ export class CdkPlaygroundEcs extends GuStack {
 		new GuCname(this, 'EcsDns', {
 			app: ecsApp,
 			ttl: Duration.minutes(1),
-			domainName: ecsDomainName,
+			domainName,
 			resourceRecord: loadBalancer.loadBalancerDnsName,
 		});
 

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -1,3 +1,4 @@
+import { NAMED_SSM_PARAMETER_PATHS } from '@guardian/cdk/lib/constants';
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
 import {
 	GuLoggingStreamNameParameter,
@@ -19,7 +20,7 @@ import {
 } from '@guardian/cdk/lib/constructs/loadbalancing';
 import { isSingletonPresentInStack } from '@guardian/cdk/lib/utils/singleton';
 import type { App } from 'aws-cdk-lib';
-import { CfnParameter, Duration } from 'aws-cdk-lib';
+import { ArnFormat, CfnParameter, Duration } from 'aws-cdk-lib';
 import { Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Repository } from 'aws-cdk-lib/aws-ecr';
 import type { Volume } from 'aws-cdk-lib/aws-ecs';
@@ -36,6 +37,7 @@ import {
 } from 'aws-cdk-lib/aws-ecs';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 // This construct is already present in GuCDK as part of `GuEc2AppExperimental`, however it is not exported.
 // TODO Update GuCDK to export this construct.
@@ -119,10 +121,27 @@ export class CdkPlaygroundEcs extends GuStack {
 			vpc: vpcThatEcsClusterConstructWillAccept,
 		});
 
+		const deployToolsAccountId = StringParameter.fromStringParameterName(
+			this,
+			'DeployToolsAccountId',
+			NAMED_SSM_PARAMETER_PATHS.DeployToolsAccountId.path,
+		);
+
+		const repositoryArn = this.formatArn({
+			account: deployToolsAccountId.stringValue,
+			arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+			resource: 'repository',
+			resourceName: this.repositoryName!,
+			service: 'ecr',
+		});
+
 		// Need to figure out how to make this cross-account, but this is fine for the simple case where the app and the
 		// ECR repo are both in the Deploy Tools account
 		const image = ContainerImage.fromEcrRepository(
-			Repository.fromRepositoryName(this, 'Repo', this.repositoryName!),
+			Repository.fromRepositoryAttributes(this, 'Repo', {
+				repositoryArn,
+				repositoryName: this.repositoryName!,
+			}),
 			imageIdentifier,
 		);
 


### PR DESCRIPTION
## What does this change?
This is to understand behaviour of pulling an image from ECR cross-accounts.

## How has this change been tested?
[Deploy it](https://riffraff.gutools.co.uk/deployment/view/be7f76ac-9286-4efe-a20f-8cba8ddf85e4) and visit the new domain - https://cdk-playground-ecs-playground.code.dev-gutools.co.uk/.

<img width="561" height="264" alt="image" src="https://github.com/user-attachments/assets/31fe9ef6-a132-4658-b2cc-c56906ec0708" />

This relies on https://github.com/guardian/riffraff-platform/pull/758, else the following error is seen at the task level:

```
CannotPullContainerError: pull image manifest has been retried 1 time(s): failed to resolve ref <REDACTED>.dkr.ecr.eu-west-1.amazonaws.com/guardian/cdk-playground@sha256:bb6b1001796e1cb4be4e7b326a89c95c813287ee9d8e6acff471d7d97c22d45f: unexpected status from HEAD request to https://<REDACTED>.dkr.ecr.eu-west-1.amazonaws.com/v2/guardian/cdk-playground/manifests/sha256:bb6b1001796e1cb4be4e7b326a89c95c813287ee9d8e6acff471d7d97c22d45f: 403 Forbidden
```