### PR TITLE
Upgrade aws-cdk libraries

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -40,25 +40,25 @@
 			}
 		},
 		"node_modules/@aws-cdk/asset-awscli-v1": {
-			"version": "2.2.273",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-			"integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+			"version": "2.2.282",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+			"integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true
 		},
 		"node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-			"integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+			"integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema": {
-			"version": "53.26.0",
-			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.26.0.tgz",
-			"integrity": "sha512-UTcu94dxaZOsgF21v0+/giVZeQ0KbFV0dyalJ1pe5AeV23pIB22aB3Z0WNWUZHdhvjaRpxjJ7poXVA8c4BKsaQ==",
+			"version": "54.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+			"integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
 			"bundleDependencies": [
 				"jsonschema",
 				"semver"
@@ -68,7 +68,7 @@
 			"peer": true,
 			"dependencies": {
 				"jsonschema": "^1.5.0",
-				"semver": "^7.8.0"
+				"semver": "^7.8.1"
 			},
 			"engines": {
 				"node": ">= 18.0.0"
@@ -85,7 +85,7 @@
 			}
 		},
 		"node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-			"version": "7.8.0",
+			"version": "7.8.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -4535,9 +4535,9 @@
 			}
 		},
 		"node_modules/aws-cdk": {
-			"version": "2.1111.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1111.0.tgz",
-			"integrity": "sha512-69AVF04cxbAhYzmeJYtUF5bs6ruNnH05EQZJfjadk5Lpg+HVaJY2NjG/2qgsMmKrfRgvLet73Ir8ehVlAaaGng==",
+			"version": "2.1126.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+			"integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -4549,9 +4549,9 @@
 			}
 		},
 		"node_modules/aws-cdk-lib": {
-			"version": "2.256.0",
-			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.0.tgz",
-			"integrity": "sha512-MtA5XOSWs+yDA42lW9cO8i+IeCHQt2EwmdPyqWf3li6mF/ptzNxnFjth6rFa5Ms+8v2VzB5cdAS+Ly1ZDGs3fg==",
+			"version": "2.258.0",
+			"resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.258.0.tgz",
+			"integrity": "sha512-OfFfg30ikBRJ3dimlzsWhPIrj6qug1p2XYsdB38CtMtcur7SufzoUczgI6kWjbQkOVcQgYzhzN29DErV0yZG7A==",
 			"bundleDependencies": [
 				"@balena/dockerignore",
 				"@aws-cdk/cloud-assembly-api",
@@ -4570,19 +4570,19 @@
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@aws-cdk/asset-awscli-v1": "2.2.273",
-				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-				"@aws-cdk/cloud-assembly-api": "^2.2.4",
-				"@aws-cdk/cloud-assembly-schema": "^53.25.0",
+				"@aws-cdk/asset-awscli-v1": "2.2.282",
+				"@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+				"@aws-cdk/cloud-assembly-api": "^2.2.5",
+				"@aws-cdk/cloud-assembly-schema": "^54.0.0",
 				"@balena/dockerignore": "^1.0.2",
 				"case": "1.6.3",
-				"fs-extra": "^11.3.3",
+				"fs-extra": "^11.3.5",
 				"ignore": "^5.3.2",
 				"jsonschema": "^1.5.0",
 				"mime-types": "^2.1.35",
-				"minimatch": "^10.2.3",
+				"minimatch": "^10.2.5",
 				"punycode": "^2.3.1",
-				"semver": "^7.7.4",
+				"semver": "^7.8.1",
 				"table": "^6.9.0",
 				"yaml": "1.10.3"
 			},
@@ -4594,7 +4594,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-			"version": "2.2.4",
+			"version": "2.2.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
@@ -4607,7 +4607,7 @@
 				"node": ">= 18.0.0"
 			},
 			"peerDependencies": {
-				"@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+				"@aws-cdk/cloud-assembly-schema": ">=53.28.0"
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -4618,7 +4618,7 @@
 			"peer": true
 		},
 		"node_modules/aws-cdk-lib/node_modules/ajv": {
-			"version": "8.18.0",
+			"version": "8.20.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -4681,7 +4681,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-			"version": "5.0.5",
+			"version": "5.0.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -4755,7 +4755,7 @@
 			"peer": true
 		},
 		"node_modules/aws-cdk-lib/node_modules/fs-extra": {
-			"version": "11.3.3",
+			"version": "11.3.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -4804,7 +4804,7 @@
 			"peer": true
 		},
 		"node_modules/aws-cdk-lib/node_modules/jsonfile": {
-			"version": "6.2.0",
+			"version": "6.2.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -4893,7 +4893,7 @@
 			}
 		},
 		"node_modules/aws-cdk-lib/node_modules/semver": {
-			"version": "7.7.4",
+			"version": "7.8.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5414,9 +5414,9 @@
 			"dev": true
 		},
 		"node_modules/constructs": {
-			"version": "10.5.1",
-			"resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
-			"integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+			"integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true


### PR DESCRIPTION
We've had a few problems with `npm ci` failing recently:

https://github.com/guardian/cdk-playground/pull/1117
https://github.com/guardian/cdk-playground/pull/1125
[Builds of `main` from this morning](https://github.com/guardian/cdk-playground/actions/runs/27190134744/job/80268247571)

The latest error is:
> npm error Invalid: lock file's semver@7.8.2 does not satisfy semver@7.8.3

I think this is happening because of https://github.com/aws/aws-cdk/issues/37949, so this PR upgrades `aws-cdk-lib` to a fixed version[^1]. I've also updated `aws-cdk` and `constructs` to ensure that everything is consistent.

Note that we're [installing these packages via peerDependencies](https://github.com/guardian/cdk/blob/1b239d551c2657a2d27e13fe9f40fa2a3d545555/package.json#L67-L71), so I ran `npm update <packageName>` locally to update the lockfile for each dependency.

[^1]: Prior to this change we were using `2.256.0`, which is an affected version.