### PR TITLE
ci: Use build-facts action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,29 +8,15 @@ on:
 jobs:
   facts:
     runs-on: ubuntu-slim
-    permissions: {} # This job doesn't need any permissions. Explicitly set it to an empty object to avoid inheriting any default permissions of the workflow.
+    permissions: {} # This job doesn't need any permissions.
     outputs:
-      BRANCH_NAME: ${{ steps.set-facts.outputs.BRANCH_NAME }}
-      BRANCH_NAME_FOR_ECR: ${{ steps.set-facts.outputs.BRANCH_NAME_FOR_ECR }}
-      BUILD_NUMBER: ${{ steps.set-facts.outputs.BUILD_NUMBER }}
-      COMMIT_SHA: ${{ steps.set-facts.outputs.COMMIT_SHA }}
+      BRANCH_NAME: ${{ steps.get-build-facts.outputs.BRANCH_NAME }}
+      BRANCH_NAME_FOR_ECR: ${{ steps.get-build-facts.outputs.BRANCH_NAME_FOR_ECR }}
+      BUILD_NUMBER: ${{ steps.get-build-facts.outputs.BUILD_NUMBER }}
+      COMMIT_SHA: ${{ steps.get-build-facts.outputs.COMMIT_SHA }}
     steps:
-      - name: Build facts
-        id: set-facts
-        env:
-          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
-          BUILD_NUMBER: ${{ github.run_number }}
-          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }} # When invoked from `pull_request`, `github.sha` is not the latest commit of the feature branch. All other times, it is.
-        run: |
-          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_OUTPUT
-          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-
-          # Remove "refs/heads/" prefix from RAW_BRANCH_NAME
-          TRIMMED_BRANCH_NAME="${RAW_BRANCH_NAME#refs/heads/}"
-          BRANCH_NAME_FOR_ECR=${TRIMMED_BRANCH_NAME//\//-}
-
-          echo "BRANCH_NAME=${TRIMMED_BRANCH_NAME}" >> $GITHUB_OUTPUT
-          echo "BRANCH_NAME_FOR_ECR=${BRANCH_NAME_FOR_ECR}" >> $GITHUB_OUTPUT
+      - uses: guardian/actions-build-facts@main
+        id: get-build-facts
 
   ci-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
