### PR TITLE
ci: Use `guardian/actions-build-facts` and `guardian/actions-publish-image`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,12 @@ jobs:
       branchName: ${{ steps.get-build-facts.outputs.branchName }}
       buildNumber: ${{ steps.get-build-facts.outputs.buildNumber }}
       commitSha: ${{ steps.get-build-facts.outputs.commitSha }}
+      buildTime: ${{ steps.build-time.outputs.buildTime }}
     steps:
+      - name: Build time
+        id: build-time
+        shell: bash
+        run: echo "buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - uses: guardian/actions-build-facts@v0.0.1
         id: get-build-facts
 
@@ -33,6 +38,7 @@ jobs:
           COMMIT_SHA: ${{ needs.facts.outputs.commitSha }}
           BUILD_NUMBER: ${{ needs.facts.outputs.buildNumber }}
           BRANCH_NAME: ${{ needs.facts.outputs.branchName }}
+          BUILD_TIME: ${{ needs.facts.outputs.buildTime }}
         run: sbt Docker/publishLocal
       - name: Normalise Docker image name
         run: docker image tag cdk-playground:1.0-SNAPSHOT ${{ github.repository }}:latest
@@ -75,6 +81,7 @@ jobs:
           COMMIT_SHA: ${{ needs.facts.outputs.commitSha }}
           BUILD_NUMBER: ${{ needs.facts.outputs.buildNumber }}
           BRANCH_NAME: ${{ needs.facts.outputs.branchName }}
+          BUILD_TIME: ${{ needs.facts.outputs.buildTime }}
           IMAGE_DIGEST: ${{ needs.ci-image.outputs.imageDigest }}
 
       # Upload our build artifacts to Riff-Raff (well, S3)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,27 +10,12 @@ jobs:
     runs-on: ubuntu-slim
     permissions: {} # This job doesn't need any permissions. Explicitly set it to an empty object to avoid inheriting any default permissions of the workflow.
     outputs:
-      BRANCH_NAME: ${{ steps.set-facts.outputs.BRANCH_NAME }}
-      BRANCH_NAME_FOR_ECR: ${{ steps.set-facts.outputs.BRANCH_NAME_FOR_ECR }}
-      BUILD_NUMBER: ${{ steps.set-facts.outputs.BUILD_NUMBER }}
-      COMMIT_SHA: ${{ steps.set-facts.outputs.COMMIT_SHA }}
+      branchName: ${{ steps.get-build-facts.outputs.branchName }}
+      buildNumber: ${{ steps.get-build-facts.outputs.buildNumber }}
+      commitSha: ${{ steps.get-build-facts.outputs.commitSha }}
     steps:
-      - name: Build facts
-        id: set-facts
-        env:
-          RAW_BRANCH_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref || 'unknown' }}
-          BUILD_NUMBER: ${{ github.run_number }}
-          COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }} # When invoked from `pull_request`, `github.sha` is not the latest commit of the feature branch. All other times, it is.
-        run: |
-          echo "BUILD_NUMBER=${BUILD_NUMBER}" >> $GITHUB_OUTPUT
-          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-
-          # Remove "refs/heads/" prefix from RAW_BRANCH_NAME
-          TRIMMED_BRANCH_NAME="${RAW_BRANCH_NAME#refs/heads/}"
-          BRANCH_NAME_FOR_ECR=${TRIMMED_BRANCH_NAME//\//-}
-
-          echo "BRANCH_NAME=${TRIMMED_BRANCH_NAME}" >> $GITHUB_OUTPUT
-          echo "BRANCH_NAME_FOR_ECR=${BRANCH_NAME_FOR_ECR}" >> $GITHUB_OUTPUT
+      - uses: guardian/actions-build-facts@v0.0.1
+        id: get-build-facts
 
   ci-image:
     runs-on: ubuntu-latest
@@ -38,38 +23,27 @@ jobs:
     permissions:
       contents: read
       id-token: write # Required to exchange for AWS credentials using OIDC
-    env:
-      REGISTRY: ${{ secrets.GU_ECR_REGISTRY }} # TODO provision this secret with https://github.com/guardian/riffraff-platform
-      REPOSITORY: ${{ github.repository }}
-      COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
-      BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
-      BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME_FOR_ECR }}
     outputs:
-      IMAGE_DIGEST: ${{ steps.obtain-image-digest.outputs.IMAGE_DIGEST }}
+      imageDigest: ${{ steps.publish-image.outputs.imageDigest }}
     steps:
-      # Checkout the branch
       - uses: actions/checkout@v6.0.2
       - uses: guardian/setup-scala@v1
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.0
+      - name: Build Docker image
+        env:
+          COMMIT_SHA: ${{ needs.facts.outputs.commitSha }}
+          BUILD_NUMBER: ${{ needs.facts.outputs.buildNumber }}
+          BRANCH_NAME: ${{ needs.facts.outputs.branchName }}
+        run: sbt Docker/publishLocal
+      - name: Normalise Docker image name
+        run: docker image tag cdk-playground:1.0-SNAPSHOT ${{ github.repository }}:latest
+      - name: Publish Image
+        uses: guardian/actions-publish-image@v0.0.2
+        id: publish-image
         with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-          mask-aws-account-id: 'true'
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.1.3
-        with:
-          mask-password: 'true'
-      - name: Build, tag, and push docker image to Amazon ECR
-        run: |
-          sbt Docker/publishLocal
-          docker push $REGISTRY/$REPOSITORY --all-tags
-      - name: Obtain image digest
-        id: obtain-image-digest
-        run: |
-          IMAGE_DIGEST=$(docker manifest inspect $REGISTRY/$REPOSITORY:sha-$COMMIT_SHA --verbose | jq -r '.Descriptor.digest')
-          echo "IMAGE_DIGEST=${IMAGE_DIGEST}" >> $GITHUB_OUTPUT
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          branchName: ${{ needs.facts.outputs.branchName }}
+          buildNumber: ${{ needs.facts.outputs.buildNumber }}
+          commitSha: ${{ needs.facts.outputs.commitSha }}
   CI:
     runs-on: ubuntu-latest
     needs:
@@ -98,10 +72,10 @@ jobs:
       # Build CDK and Play (in sequence)
       - run: ./script/ci
         env:
-          COMMIT_SHA: ${{ needs.facts.outputs.COMMIT_SHA }}
-          BUILD_NUMBER: ${{ needs.facts.outputs.BUILD_NUMBER }}
-          BRANCH_NAME: ${{ needs.facts.outputs.BRANCH_NAME }}
-          IMAGE_DIGEST: ${{ needs.ci-image.outputs.IMAGE_DIGEST }}
+          COMMIT_SHA: ${{ needs.facts.outputs.commitSha }}
+          BUILD_NUMBER: ${{ needs.facts.outputs.buildNumber }}
+          BRANCH_NAME: ${{ needs.facts.outputs.branchName }}
+          IMAGE_DIGEST: ${{ needs.ci-image.outputs.imageDigest }}
 
       # Upload our build artifacts to Riff-Raff (well, S3)
       - uses: guardian/actions-riff-raff@v4

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val root = (project in file("."))
       sbtVersion,
 
       BuildInfoKey.sbtbuildinfoConstantEntry("buildNumber", env("BUILD_NUMBER")),
-      BuildInfoKey.sbtbuildinfoConstantEntry("buildTime", System.currentTimeMillis),
+      BuildInfoKey.sbtbuildinfoConstantEntry("buildTime", env("BUILD_TIME")),
       BuildInfoKey.sbtbuildinfoConstantEntry("gitCommitId", env("COMMIT_SHA")),
       BuildInfoKey.sbtbuildinfoConstantEntry("branch", env("BRANCH_NAME")),
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -55,18 +55,5 @@ lazy val root = (project in file("."))
     ),
 
     dockerBaseImage := "amazoncorretto:21-alpine",
-    dockerBuildxPlatforms := Seq("linux/amd64"),
-    dockerAliases := Seq(
-      "sha"    -> env("COMMIT_SHA").getOrElse("dev"),
-      "build"  -> env("BUILD_NUMBER").getOrElse("dev"),
-      "branch" -> env("BRANCH_NAME").getOrElse("dev"),
-      "lifecycle" -> s"${env("BRANCH_NAME").getOrElse("dev")}-${env("BUILD_NUMBER").getOrElse("dev")}",
-    ).map { case (prefix, value) =>
-      DockerAlias(
-        name = name.value,
-        registryHost = Some(s"${env("REGISTRY").getOrElse("dev")}/guardian"),
-        username = None,
-        tag = Some(s"$prefix-$value"),
-      )
-    }
+    dockerBuildxPlatforms := Seq("linux/amd64")
   )


### PR DESCRIPTION
## What does this change?
Adjusts the CI workflow to use [`guardian/actions-build-facts`](https://github.com/guardian/actions-build-facts) and [`guardian/actions-publish-image`](https://github.com/guardian/actions-publish-image). These Actions encapsulate reusable logic and allow us to remove some complexity.

## How has this change been tested?
Observing the build log and the resulting image in ECR having the correct tags:

<img width="1090" height="331" alt="image" src="https://github.com/user-attachments/assets/eda806ae-9a7a-4ab4-86f6-6b5a87d4a527" />

I've also [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/7011f2d2-b1d1-498c-898c-4d0e3142a452) and confirmed the manifest returned by this app still shows correct values:

<img width="540" height="258" alt="image" src="https://github.com/user-attachments/assets/3756a505-b41e-486c-b160-dae36a213422" />

## How can we measure success?
This change can be considered a demonstration of the aforementioned Actions before we update https://github.com/guardian/dotcom-rendering to also push to AWS ECR.