### PR TITLE
feat: Evenly weight traffic between EC2 and ECS

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -1111,13 +1111,13 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
                   "TargetGroupArn": {
                     "Ref": "TargetGroupCdkplayground7A453FC2",
                   },
-                  "Weight": 500,
+                  "Weight": 1,
                 },
                 {
                   "TargetGroupArn": {
                     "Ref": "EcsTargetGroupCdkplayground55757231",
                   },
-                  "Weight": 499,
+                  "Weight": 1,
                 },
               ],
             },

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -82,8 +82,8 @@ export class CdkPlayground extends GuStack {
 				},
 			},
 			targetGroupWeights: {
-				ec2: 500,
-				ecs: 499,
+				ec2: 1,
+				ecs: 1,
 			},
 		});
 


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/cdk/releases/tag/v63.6.2, updates the target group weighting to evenly split traffic between EC2 and ECS.

[Successfully deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/8a4cacaf-ad3f-4497-82a0-a1e8463b57f5).