### PR TITLE
Use cdk branch jb/test-route-deterministically-to-ecs-or-ec2 for testing

### DIFF
--- a/app/controllers/ManagementController.scala
+++ b/app/controllers/ManagementController.scala
@@ -8,7 +8,13 @@ import scala.io.Source
 
 class ManagementController (override val controllerComponents: ControllerComponents) extends BaseController with Logging {
   def manifest: Action[AnyContent] = Action {
-    Ok(Json.parse(BuildInfo.toJson))
+    val buildInfoJson = Json.parse(BuildInfo.toJson).as[play.api.libs.json.JsObject]
+
+    val backend =
+      if (sys.env.contains("ECS_CONTAINER_METADATA_URI_V4")) "ecs"
+      else "ec2"
+
+    Ok(buildInfoJson ++ Json.obj("backend" -> backend))
   }
 
   def tags: Action[AnyContent] = Action {

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -307,6 +307,8 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
     "EcsService81FC6EF6": {
       "DependsOn": [
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
+        "ListenerCdkplaygroundDeterministicRouteToEc2Rule2BB42C95",
+        "ListenerCdkplaygroundDeterministicRouteToEcsRule31238CBD",
         "ListenerCdkplaygroundA8D9CA6F",
       ],
       "Properties": {
@@ -1090,6 +1092,62 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
         "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "ListenerCdkplaygroundDeterministicRouteToEc2Rule2BB42C95": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "TargetGroupCdkplayground7A453FC2",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "http-header",
+            "HttpHeaderConfig": {
+              "HttpHeaderName": "X-Gu-Target-Group",
+              "Values": [
+                "ec2",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerCdkplaygroundA8D9CA6F",
+        },
+        "Priority": 10,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
+    "ListenerCdkplaygroundDeterministicRouteToEcsRule31238CBD": {
+      "Properties": {
+        "Actions": [
+          {
+            "TargetGroupArn": {
+              "Ref": "EcsTargetGroupCdkplayground55757231",
+            },
+            "Type": "forward",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "http-header",
+            "HttpHeaderConfig": {
+              "HttpHeaderName": "X-Gu-Target-Group",
+              "Values": [
+                "ecs",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerCdkplaygroundA8D9CA6F",
+        },
+        "Priority": 11,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
     },
     "LoadBalancerCdkplayground7C6B4D97": {
       "Properties": {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -85,6 +85,9 @@ export class CdkPlayground extends GuStack {
 				ec2: 1,
 				ecs: 1,
 			},
+			deterministicRouting: {
+				enabled: true,
+			},
 		});
 
 		new GuCname(this, 'EC2AppDNS', {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -85,9 +85,6 @@ export class CdkPlayground extends GuStack {
 				ec2: 1,
 				ecs: 1,
 			},
-			deterministicRouting: {
-				enabled: true,
-			},
 		});
 
 		new GuCname(this, 'EC2AppDNS', {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"@aws-sdk/client-auto-scaling": "3.1079.0",
 		"@aws-sdk/credential-providers": "3.1079.0",
-		"@guardian/cdk": "64.0.0",
+    "@guardian/cdk": "github:guardian/cdk#jb/route-deterministically-to-ecs-or-ec2",
 		"@guardian/eslint-config": "14.0.1",
 		"@guardian/prettier": "11.0.0",
 		"@types/aws-lambda": "8.10.162",


### PR DESCRIPTION
## What does this change?

Uses cdk branch jb/route-deterministically-to-ecs-or-ec2 for testing

## How can we measure success?

Everything works as before and deterministic routing works too.
