### PR TITLE
feat: Allow us to "ssh" to a container

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -204,6 +204,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
           "Type": "ECS",
         },
         "EnableECSManagedTags": false,
+        "EnableExecuteCommand": false,
         "HealthCheckGracePeriodSeconds": 60,
         "LaunchType": "FARGATE",
         "LoadBalancers": [

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -359,6 +359,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
     },
     "EcsService81FC6EF6": {
       "DependsOn": [
+        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
         "ListenerCdkplaygroundDeterministicRouteToEc2Rule2BB42C95",
         "ListenerCdkplaygroundDeterministicRouteToEcsRule31238CBD",
@@ -385,6 +386,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
           "Type": "ECS",
         },
         "EnableECSManagedTags": false,
+        "EnableExecuteCommand": true,
         "HealthCheckGracePeriodSeconds": 60,
         "LaunchType": "FARGATE",
         "LoadBalancers": [
@@ -447,6 +449,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
     },
     "EcsServiceTaskCountTarget02FCCE22": {
       "DependsOn": [
+        "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
       ],
       "Properties": {
@@ -538,6 +541,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
                 ],
               ],
             },
+            "LinuxParameters": {
+              "Capabilities": {},
+              "InitProcessEnabled": true,
+            },
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -556,7 +563,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
                 "Protocol": "tcp",
               },
             ],
-            "ReadonlyRootFilesystem": true,
+            "ReadonlyRootFilesystem": false,
             "VersionConsistency": "disabled",
           },
           {
@@ -848,6 +855,46 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": "logs:DescribeLogGroups",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EcsTaskDefinitionTaskRoleDefaultPolicy1FD2F057",
+        "Roles": [
+          {
+            "Ref": "EcsTaskDefinitionTaskRoleB7B6D8DD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "GetDistributablePolicyCdkplaygroundBFB4D02B": {
       "Properties": {

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -80,6 +80,7 @@ export class CdkPlayground extends GuStack {
 					minimumTasks: 1,
 					maximumTasks: 2,
 				},
+				enableExecuteCommand: true,
 			},
 			targetGroupWeights: {
 				ec2: 1,

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@aws-sdk/client-auto-scaling": "3.1101.0",
 				"@aws-sdk/credential-providers": "3.1101.0",
-				"@guardian/cdk": "64.3.0",
+				"@guardian/cdk": "github:guardian/cdk#aa/ecs-execute-command",
 				"@guardian/eslint-config": "16.0.0",
 				"@guardian/prettier": "11.0.0",
 				"@types/aws-lambda": "8.10.162",
@@ -995,21 +995,21 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-			"integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+			"integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.1.0",
+				"@emnapi/wasi-threads": "1.2.3",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-			"integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1018,9 +1018,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+			"integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1703,8 +1703,7 @@
 		},
 		"node_modules/@guardian/cdk": {
 			"version": "64.3.0",
-			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-64.3.0.tgz",
-			"integrity": "sha512-Lfkac9pqB0meaVLLyg26c4+imgCyXeAaCJcWSUgm450REsn3xXkREsD4D7NqsPjGk7J0T9QrwljQZ93hTeNYow==",
+			"resolved": "git+ssh://git@github.com/guardian/cdk.git#93b319612314eaafd223dc14bb6005fe5da96689",
 			"dev": true,
 			"dependencies": {
 				"@aws-sdk/client-ec2": "^3.1087.0",
@@ -2629,9 +2628,9 @@
 			"dev": true
 		},
 		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+			"integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -3179,6 +3178,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3193,6 +3195,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3207,6 +3212,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3221,6 +3229,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3235,6 +3246,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3249,6 +3263,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3263,6 +3280,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3277,6 +3297,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"@aws-sdk/client-auto-scaling": "3.1101.0",
 		"@aws-sdk/credential-providers": "3.1101.0",
-		"@guardian/cdk": "64.3.0",
+		"@guardian/cdk": "github:guardian/cdk#aa/ecs-execute-command",
 		"@guardian/eslint-config": "16.0.0",
 		"@guardian/prettier": "11.0.0",
 		"@types/aws-lambda": "8.10.162",


### PR DESCRIPTION
## What does this change?
A test of https://github.com/guardian/cdk/pull/2940.

## How has this change been tested?
After deploying we can follow the [instructions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec-run.html) to connect to a container:

```console
~ $ aws ecs execute-command --cluster deploy-CODE-cdk-playground-cdkplaygroundEcsClusterF-REDACTED --task afd578acf-REDACTED --container cdk-playground --interactive --command '/bin/sh'

The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.

Starting session with SessionId: ecs-execute-command-ig5g86inr9xcfhhisl7flglste
/opt/docker # ls -lah
total 28K    
drwxr-xr-x    1 root     root        4.0K Jul 20 12:03 .
drwxr-xr-x    1 root     root        4.0K Jul 20 12:03 ..
-r--r--r--    1 demiourgos728 root        1.2K Jul 20 12:03 README.md
dr-xr-xr-x    2 demiourgos728 root        4.0K Jul 20 12:03 bin
dr-xr-xr-x    2 demiourgos728 root        4.0K Jul 20 12:03 conf
dr-xr-xr-x    2 demiourgos728 root        4.0K Jul 20 12:03 lib
dr-xr-xr-x    3 demiourgos728 root        4.0K Jul 20 12:03 share
/opt/docker # 
```