### PR TITLE
ECS task lifecycle

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -729,6 +729,174 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::IAM::Policy",
     },
+    "HealthCheckLogDelivery": {
+      "DependsOn": [
+        "HealthCheckLogsDeliveryPolicy",
+        "HealthCheckLogSource",
+      ],
+      "Properties": {
+        "DeliveryDestinationArn": {
+          "Fn::GetAtt": [
+            "HealthCheckLogDestination",
+            "Arn",
+          ],
+        },
+        "DeliverySourceName": "cdk-playground-CODE-health-check",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::Delivery",
+    },
+    "HealthCheckLogDestination": {
+      "Properties": {
+        "DestinationResourceArn": {
+          "Fn::GetAtt": [
+            "HealthCheckLogs807FF78A",
+            "Arn",
+          ],
+        },
+        "Name": "cdk-playground-CODE-health-check",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::DeliveryDestination",
+    },
+    "HealthCheckLogSource": {
+      "Properties": {
+        "LogType": "ALB_HEALTH_CHECK_LOGS",
+        "Name": "cdk-playground-CODE-health-check",
+        "ResourceArn": {
+          "Ref": "LoadBalancerCdkplayground7C6B4D97",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::DeliverySource",
+    },
+    "HealthCheckLogs807FF78A": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "LogGroupName": "/aws/elasticloadbalancing/cdk-playground-CODE-health-check",
+        "RetentionInDays": 7,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "HealthCheckLogsDeliveryPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Fn::Join": [
+            "",
+            [
+              "{"Version":"2012-10-17","Statement":[{"Sid":"AllowLogDeliveryWrite","Effect":"Allow","Principal":{"Service":"delivery.logs.amazonaws.com"},"Action":["logs:CreateLogStream","logs:PutLogEvents"],"Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":logs:eu-west-1:",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":log-group:/aws/elasticloadbalancing/cdk-playground-CODE-health-check:log-stream:*","Condition":{"StringEquals":{"aws:SourceAccount":"",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ""},"ArnLike":{"aws:SourceArn":"",
+              {
+                "Fn::GetAtt": [
+                  "HealthCheckLogSource",
+                  "Arn",
+                ],
+              },
+              ""}}}]}",
+            ],
+          ],
+        },
+        "PolicyName": "cdk-playground-CODE-health-check-logs",
+      },
+      "Type": "AWS::Logs::ResourcePolicy",
+    },
     "ListenerCdkplaygroundA8D9CA6F": {
       "Properties": {
         "Certificates": [

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -39,18 +39,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Description": "S3 bucket to store your access logs",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fArtifactHash6449FA76": {
-      "Description": "Artifact hash for asset "8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0f"",
-      "Type": "String",
-    },
-    "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3Bucket5925A2C0": {
-      "Description": "S3 bucket for asset "8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0f"",
-      "Type": "String",
-    },
-    "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3VersionKey3BAC1810": {
-      "Description": "S3 key for asset version "8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0f"",
-      "Type": "String",
-    },
     "DeployToolsAccountIdParameter": {
       "Default": "/organisation/accounts/deployTools",
       "Type": "AWS::SSM::Parameter::Value<String>",
@@ -81,136 +69,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     },
   },
   "Resources": {
-    "AWS679f53fac002430cb0da5b7982bd22872D164C4C": {
-      "DependsOn": [
-        "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3Bucket5925A2C0",
-          },
-          "S3Key": {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Fn::Select": [
-                    0,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3VersionKey3BAC1810",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                {
-                  "Fn::Select": [
-                    1,
-                    {
-                      "Fn::Split": [
-                        "||",
-                        {
-                          "Ref": "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3VersionKey3BAC1810",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
-        },
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs22.x",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "gu:riff-raff:project",
-            "Value": "devx::cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "Timeout": 120,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "gu:riff-raff:project",
-            "Value": "devx::cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
     "CertificateCdkplayground47FCF7D9": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -768,80 +626,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::IAM::Role",
     },
-    "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A844FC72981": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84CustomResourcePolicy90BE36B4",
-      ],
-      "Properties": {
-        "Create": {
-          "Fn::Join": [
-            "",
-            [
-              "{"service":"CloudWatchLogs","action":"putResourcePolicy","parameters":{"policyName":"CdkPlaygroundEcsCODEEventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84E8FF5D81","policyDocument":"{\\"Statement\\":[{\\"Action\\":[\\"logs:PutLogEvents\\",\\"logs:CreateLogStream\\"],\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"events.amazonaws.com\\"},\\"Resource\\":\\"",
-              {
-                "Fn::GetAtt": [
-                  "TaskStateEvents4E5081CA",
-                  "Arn",
-                ],
-              },
-              "\\"}],\\"Version\\":\\"2012-10-17\\"}"},"physicalResourceId":{"id":"EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84"}}",
-            ],
-          ],
-        },
-        "Delete": "{"service":"CloudWatchLogs","action":"deleteResourcePolicy","parameters":{"policyName":"CdkPlaygroundEcsCODEEventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84E8FF5D81"},"ignoreErrorCodesMatching":"ResourceNotFoundException"}",
-        "InstallLatestAwsSdk": true,
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
-            "Arn",
-          ],
-        },
-        "Update": {
-          "Fn::Join": [
-            "",
-            [
-              "{"service":"CloudWatchLogs","action":"putResourcePolicy","parameters":{"policyName":"CdkPlaygroundEcsCODEEventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84E8FF5D81","policyDocument":"{\\"Statement\\":[{\\"Action\\":[\\"logs:PutLogEvents\\",\\"logs:CreateLogStream\\"],\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"events.amazonaws.com\\"},\\"Resource\\":\\"",
-              {
-                "Fn::GetAtt": [
-                  "TaskStateEvents4E5081CA",
-                  "Arn",
-                ],
-              },
-              "\\"}],\\"Version\\":\\"2012-10-17\\"}"},"physicalResourceId":{"id":"EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84"}}",
-            ],
-          ],
-        },
-      },
-      "Type": "Custom::CloudwatchLogResourcePolicy",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84CustomResourcePolicy90BE36B4": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "logs:PutResourcePolicy",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "logs:DeleteResourcePolicy",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84CustomResourcePolicy90BE36B4",
-        "Roles": [
-          {
-            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490": {
       "Properties": {
         "GroupDescription": "Allow all outbound HTTPS traffic",
@@ -1159,7 +943,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::IAM::Policy",
     },
-    "TaskStateChangeRule57F6E27C": {
+    "TaskStateChangeRule": {
       "Properties": {
         "EventPattern": {
           "detail": {
@@ -1179,7 +963,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             "aws.ecs",
           ],
         },
-        "State": "ENABLED",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1223,7 +1006,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
                 ],
               ],
             },
-            "Id": "Target0",
+            "Id": "TaskStateEventsLog",
           },
         ],
       },
@@ -1232,6 +1015,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     "TaskStateEvents4E5081CA": {
       "DeletionPolicy": "Delete",
       "Properties": {
+        "LogGroupName": "/aws/events/cdk-playground-CODE-task-state",
         "RetentionInDays": 7,
         "Tags": [
           {
@@ -1258,6 +1042,34 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Delete",
+    },
+    "TaskStateEventsPolicy": {
+      "Properties": {
+        "PolicyDocument": {
+          "Fn::Join": [
+            "",
+            [
+              "{"Version":"2012-10-17","Statement":[{"Sid":"AllowEventBridgeToLog","Effect":"Allow","Principal":{"Service":"events.amazonaws.com"},"Action":["logs:CreateLogStream","logs:PutLogEvents"],"Resource":"",
+              {
+                "Fn::GetAtt": [
+                  "TaskStateEvents4E5081CA",
+                  "Arn",
+                ],
+              },
+              "","Condition":{"ArnEquals":{"aws:SourceArn":"",
+              {
+                "Fn::GetAtt": [
+                  "TaskStateChangeRule",
+                  "Arn",
+                ],
+              },
+              ""}}}]}",
+            ],
+          ],
+        },
+        "PolicyName": "cdk-playground-CODE-task-state-events",
+      },
+      "Type": "AWS::Logs::ResourcePolicy",
     },
     "cdkplaygroundEcsClusterF9ADCF3E": {
       "Properties": {

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -108,6 +108,24 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
     },
+    "CpuTargetTracking785C9A34": {
+      "Properties": {
+        "PolicyName": "CdkPlaygroundEcsCODECpuTargetTracking49E9E1E2",
+        "PolicyType": "TargetTrackingScaling",
+        "ScalingTargetId": {
+          "Ref": "EcsServiceTaskCountTarget02FCCE22",
+        },
+        "TargetTrackingScalingPolicyConfiguration": {
+          "PredefinedMetricSpecification": {
+            "PredefinedMetricType": "ECSServiceAverageCPUUtilizationHighResolution",
+          },
+          "ScaleInCooldown": 60,
+          "ScaleOutCooldown": 60,
+          "TargetValue": 50,
+        },
+      },
+      "Type": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    },
     "EcsDns": {
       "Properties": {
         "Name": "cdk-playground-ecs.code.dev-gutools.co.uk",
@@ -162,6 +180,16 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
             },
           },
         ],
+        "Monitoring": {
+          "MetricConfigurations": [
+            {
+              "MetricNames": [
+                "CPUUtilization",
+              ],
+              "ResolutionSeconds": 20,
+            },
+          ],
+        },
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
             "AssignPublicIp": "DISABLED",
@@ -212,7 +240,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         "EcsTaskDefinitionTaskRoleB7B6D8DD",
       ],
       "Properties": {
-        "MaxCapacity": 2,
+        "MaxCapacity": 10,
         "MinCapacity": 1,
         "ResourceId": {
           "Fn::Join": [

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -39,6 +39,18 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       "Description": "S3 bucket to store your access logs",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
+    "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fArtifactHash6449FA76": {
+      "Description": "Artifact hash for asset "8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0f"",
+      "Type": "String",
+    },
+    "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3Bucket5925A2C0": {
+      "Description": "S3 bucket for asset "8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0f"",
+      "Type": "String",
+    },
+    "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3VersionKey3BAC1810": {
+      "Description": "S3 key for asset version "8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0f"",
+      "Type": "String",
+    },
     "DeployToolsAccountIdParameter": {
       "Default": "/organisation/accounts/deployTools",
       "Type": "AWS::SSM::Parameter::Value<String>",
@@ -69,6 +81,136 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
     },
   },
   "Resources": {
+    "AWS679f53fac002430cb0da5b7982bd22872D164C4C": {
+      "DependsOn": [
+        "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3Bucket5925A2C0",
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3VersionKey3BAC1810",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParameters8b1c21efe0e24332f92ed71e98107d8a27ee1544c62b7b191805e0913fcfdf0fS3VersionKey3BAC1810",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 120,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
     "CertificateCdkplayground47FCF7D9": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -626,6 +768,80 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
       },
       "Type": "AWS::IAM::Role",
     },
+    "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A844FC72981": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84CustomResourcePolicy90BE36B4",
+      ],
+      "Properties": {
+        "Create": {
+          "Fn::Join": [
+            "",
+            [
+              "{"service":"CloudWatchLogs","action":"putResourcePolicy","parameters":{"policyName":"CdkPlaygroundEcsCODEEventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84E8FF5D81","policyDocument":"{\\"Statement\\":[{\\"Action\\":[\\"logs:PutLogEvents\\",\\"logs:CreateLogStream\\"],\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"events.amazonaws.com\\"},\\"Resource\\":\\"",
+              {
+                "Fn::GetAtt": [
+                  "TaskStateEvents4E5081CA",
+                  "Arn",
+                ],
+              },
+              "\\"}],\\"Version\\":\\"2012-10-17\\"}"},"physicalResourceId":{"id":"EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84"}}",
+            ],
+          ],
+        },
+        "Delete": "{"service":"CloudWatchLogs","action":"deleteResourcePolicy","parameters":{"policyName":"CdkPlaygroundEcsCODEEventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84E8FF5D81"},"ignoreErrorCodesMatching":"ResourceNotFoundException"}",
+        "InstallLatestAwsSdk": true,
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": {
+          "Fn::Join": [
+            "",
+            [
+              "{"service":"CloudWatchLogs","action":"putResourcePolicy","parameters":{"policyName":"CdkPlaygroundEcsCODEEventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84E8FF5D81","policyDocument":"{\\"Statement\\":[{\\"Action\\":[\\"logs:PutLogEvents\\",\\"logs:CreateLogStream\\"],\\"Effect\\":\\"Allow\\",\\"Principal\\":{\\"Service\\":\\"events.amazonaws.com\\"},\\"Resource\\":\\"",
+              {
+                "Fn::GetAtt": [
+                  "TaskStateEvents4E5081CA",
+                  "Arn",
+                ],
+              },
+              "\\"}],\\"Version\\":\\"2012-10-17\\"}"},"physicalResourceId":{"id":"EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84"}}",
+            ],
+          ],
+        },
+      },
+      "Type": "Custom::CloudwatchLogResourcePolicy",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84CustomResourcePolicy90BE36B4": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "logs:PutResourcePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": "logs:DeleteResourcePolicy",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EventsLogGroupPolicyCdkPlaygroundEcsCODETaskStateChangeRule0B555A84CustomResourcePolicy90BE36B4",
+        "Roles": [
+          {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "GuHttpsEgressSecurityGroupCdkplaygroundecs59F0C490": {
       "Properties": {
         "GroupDescription": "Allow all outbound HTTPS traffic",
@@ -942,6 +1158,106 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "TaskStateChangeRule57F6E27C": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cdkplaygroundEcsClusterF9ADCF3E",
+                  "Arn",
+                ],
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:",
+                  {
+                    "Ref": "AWS::Partition",
+                  },
+                  ":logs:eu-west-1:",
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ":log-group:",
+                  {
+                    "Ref": "TaskStateEvents4E5081CA",
+                  },
+                ],
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "TaskStateEvents4E5081CA": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "RetentionInDays": 7,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "cdkplaygroundEcsClusterF9ADCF3E": {
       "Properties": {

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -2,8 +2,13 @@ import { AccessScope } from '@guardian/cdk/lib/constants/access';
 import { GuStack, type GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuLoadBalancedAppExperimental } from '@guardian/cdk/lib/experimental/patterns/gu-load-balanced-app';
-import type { App } from 'aws-cdk-lib';
+import type { App, CfnResource } from 'aws-cdk-lib';
 import { ArnFormat, Duration, RemovalPolicy } from 'aws-cdk-lib';
+import {
+	type PredefinedMetric,
+	TargetTrackingScalingPolicy,
+} from 'aws-cdk-lib/aws-applicationautoscaling';
+import type { ScalableTaskCount } from 'aws-cdk-lib/aws-ecs';
 import { CfnRule } from 'aws-cdk-lib/aws-events';
 import {
 	CfnDelivery,
@@ -56,11 +61,34 @@ export class CdkPlaygroundEcs extends GuStack {
 					repositoryName: 'guardian/cdk-playground',
 					scaling: {
 						minimumTasks: 1,
-						maximumTasks: 2,
+						maximumTasks: 10,
 					},
 				},
 			},
 		);
+
+		const scalableTaskCount = ecsService!.node.findChild(
+			'TaskCount',
+		) as ScalableTaskCount;
+
+		const cfnService = ecsService!.node.defaultChild as CfnResource;
+		cfnService.addPropertyOverride('Monitoring', {
+			MetricConfigurations: [
+				{
+					MetricNames: ['CPUUtilization'],
+					ResolutionSeconds: 20,
+				},
+			],
+		});
+
+		new TargetTrackingScalingPolicy(this, 'CpuTargetTracking', {
+			scalingTarget: scalableTaskCount,
+			targetValue: 50,
+			predefinedMetric:
+				'ECSServiceAverageCPUUtilizationHighResolution' as unknown as PredefinedMetric,
+			scaleOutCooldown: Duration.seconds(60),
+			scaleInCooldown: Duration.seconds(60),
+		});
 
 		// Deliver per-health-check-attempt results (PASS/FAIL, latency, target
 		// IP:port, reason code) straight to CloudWatch Logs as vended logs, so we

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -3,7 +3,10 @@ import { GuStack, type GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuLoadBalancedAppExperimental } from '@guardian/cdk/lib/experimental/patterns/gu-load-balanced-app';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { Rule } from 'aws-cdk-lib/aws-events';
+import { CloudWatchLogGroup } from 'aws-cdk-lib/aws-events-targets';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	/**
@@ -30,24 +33,45 @@ export class CdkPlaygroundEcs extends GuStack {
 		const app = 'cdk-playground';
 		const domainName = 'cdk-playground-ecs.code.dev-gutools.co.uk';
 
-		const { loadBalancer } = new GuLoadBalancedAppExperimental(this, {
-			access: { scope: AccessScope.PUBLIC },
-			app,
-			applicationPort: 9000,
-			certificateProps: {
-				domainName,
-			},
-			monitoringConfiguration: { noMonitoring: true },
-			ecsProps: {
-				imageIdentifier,
-				memoryLimitMiB: 2048,
-				cpu: 1024,
-				repositoryName: 'guardian/cdk-playground',
-				scaling: {
-					minimumTasks: 1,
-					maximumTasks: 2,
+		const { loadBalancer, ecsService } = new GuLoadBalancedAppExperimental(
+			this,
+			{
+				access: { scope: AccessScope.PUBLIC },
+				app,
+				applicationPort: 9000,
+				certificateProps: {
+					domainName,
+				},
+				monitoringConfiguration: { noMonitoring: true },
+				ecsProps: {
+					imageIdentifier,
+					memoryLimitMiB: 2048,
+					cpu: 1024,
+					repositoryName: 'guardian/cdk-playground',
+					scaling: {
+						minimumTasks: 1,
+						maximumTasks: 2,
+					},
 				},
 			},
+		);
+
+		// Record every ECS task lifecycle transition (PROVISIONING → ... → STOPPED)
+		// so we can reconstruct a per-state timeline for scale-out latency analysis.
+		const taskStateEvents = new LogGroup(this, 'TaskStateEvents', {
+			retention: RetentionDays.ONE_WEEK,
+			removalPolicy: RemovalPolicy.DESTROY,
+		});
+
+		new Rule(this, 'TaskStateChangeRule', {
+			eventPattern: {
+				source: ['aws.ecs'],
+				detailType: ['ECS Task State Change'],
+				detail: {
+					clusterArn: [ecsService!.cluster.clusterArn],
+				},
+			},
+			targets: [new CloudWatchLogGroup(taskStateEvents)],
 		});
 
 		new GuCname(this, 'EcsDns', {

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -6,6 +6,9 @@ import type { App } from 'aws-cdk-lib';
 import { ArnFormat, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { CfnRule } from 'aws-cdk-lib/aws-events';
 import {
+	CfnDelivery,
+	CfnDeliveryDestination,
+	CfnDeliverySource,
 	CfnResourcePolicy,
 	LogGroup,
 	RetentionDays,
@@ -58,6 +61,78 @@ export class CdkPlaygroundEcs extends GuStack {
 				},
 			},
 		);
+
+		// Deliver per-health-check-attempt results (PASS/FAIL, latency, target
+		// IP:port, reason code) straight to CloudWatch Logs as vended logs, so we
+		// can query them alongside task-state events to reconstruct the
+		// registration → healthy phase of a task's lifecycle.
+		// See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-logs.html
+		const healthCheckLogsName = `/aws/elasticloadbalancing/${app}-${this.stage}-health-check`;
+		const healthCheckLogs = new LogGroup(this, 'HealthCheckLogs', {
+			logGroupName: healthCheckLogsName,
+			retention: RetentionDays.ONE_WEEK,
+			removalPolicy: RemovalPolicy.DESTROY,
+		});
+
+		const healthCheckLogSource = new CfnDeliverySource(
+			this,
+			'HealthCheckLogSource',
+			{
+				name: `${app}-${this.stage}-health-check`,
+				logType: 'ALB_HEALTH_CHECK_LOGS',
+				resourceArn: loadBalancer.loadBalancerArn,
+			},
+		);
+
+		const healthCheckLogDestination = new CfnDeliveryDestination(
+			this,
+			'HealthCheckLogDestination',
+			{
+				name: `${app}-${this.stage}-health-check`,
+				destinationResourceArn: healthCheckLogs.logGroupArn,
+			},
+		);
+
+		// Allow the CloudWatch Logs delivery service to write to the log group.
+		const healthCheckLogsPolicy = new CfnResourcePolicy(
+			this,
+			'HealthCheckLogsDeliveryPolicy',
+			{
+				policyName: `${app}-${this.stage}-health-check-logs`,
+				policyDocument: JSON.stringify({
+					Version: '2012-10-17',
+					Statement: [
+						{
+							Sid: 'AllowLogDeliveryWrite',
+							Effect: 'Allow',
+							Principal: { Service: 'delivery.logs.amazonaws.com' },
+							Action: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+							Resource: this.formatArn({
+								service: 'logs',
+								resource: 'log-group',
+								resourceName: `${healthCheckLogsName}:log-stream:*`,
+								arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+							}),
+							Condition: {
+								StringEquals: { 'aws:SourceAccount': this.account },
+								ArnLike: { 'aws:SourceArn': healthCheckLogSource.attrArn },
+							},
+						},
+					],
+				}),
+			},
+		);
+
+		const healthCheckLogDelivery = new CfnDelivery(
+			this,
+			'HealthCheckLogDelivery',
+			{
+				deliverySourceName: healthCheckLogSource.name,
+				deliveryDestinationArn: healthCheckLogDestination.attrArn,
+			},
+		);
+		healthCheckLogDelivery.addDependency(healthCheckLogSource);
+		healthCheckLogDelivery.addDependency(healthCheckLogsPolicy);
 
 		// Record every ECS task lifecycle transition (PROVISIONING → ... → STOPPED)
 		// so we can reconstruct a per-state timeline for scale-out latency analysis.

--- a/cdk/lib/cdk-playground-ecs.ts
+++ b/cdk/lib/cdk-playground-ecs.ts
@@ -3,10 +3,13 @@ import { GuStack, type GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuLoadBalancedAppExperimental } from '@guardian/cdk/lib/experimental/patterns/gu-load-balanced-app';
 import type { App } from 'aws-cdk-lib';
-import { Duration, RemovalPolicy } from 'aws-cdk-lib';
-import { Rule } from 'aws-cdk-lib/aws-events';
-import { CloudWatchLogGroup } from 'aws-cdk-lib/aws-events-targets';
-import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { ArnFormat, Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { CfnRule } from 'aws-cdk-lib/aws-events';
+import {
+	CfnResourcePolicy,
+	LogGroup,
+	RetentionDays,
+} from 'aws-cdk-lib/aws-logs';
 
 interface CdkPlaygroundEcsProps extends Omit<GuStackProps, 'stack' | 'stage'> {
 	/**
@@ -59,19 +62,53 @@ export class CdkPlaygroundEcs extends GuStack {
 		// Record every ECS task lifecycle transition (PROVISIONING → ... → STOPPED)
 		// so we can reconstruct a per-state timeline for scale-out latency analysis.
 		const taskStateEvents = new LogGroup(this, 'TaskStateEvents', {
+			logGroupName: `/aws/events/${app}-${this.stage}-task-state`,
 			retention: RetentionDays.ONE_WEEK,
 			removalPolicy: RemovalPolicy.DESTROY,
 		});
 
-		new Rule(this, 'TaskStateChangeRule', {
+		// Use a low-level CfnRule + native resource policy rather than the L2
+		// CloudWatchLogGroup target: the L2 target injects a Lambda-backed custom
+		// resource (an asset), which requires `cdk deploy`. This keeps the stack
+		// deployable via plain CloudFormation changesets.
+		const taskStateRule = new CfnRule(this, 'TaskStateChangeRule', {
 			eventPattern: {
 				source: ['aws.ecs'],
-				detailType: ['ECS Task State Change'],
+				'detail-type': ['ECS Task State Change'],
 				detail: {
 					clusterArn: [ecsService!.cluster.clusterArn],
 				},
 			},
-			targets: [new CloudWatchLogGroup(taskStateEvents)],
+			targets: [
+				{
+					id: 'TaskStateEventsLog',
+					arn: this.formatArn({
+						service: 'logs',
+						resource: 'log-group',
+						resourceName: taskStateEvents.logGroupName,
+						arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+					}),
+				},
+			],
+		});
+
+		new CfnResourcePolicy(this, 'TaskStateEventsPolicy', {
+			policyName: `${app}-${this.stage}-task-state-events`,
+			policyDocument: JSON.stringify({
+				Version: '2012-10-17',
+				Statement: [
+					{
+						Sid: 'AllowEventBridgeToLog',
+						Effect: 'Allow',
+						Principal: { Service: 'events.amazonaws.com' },
+						Action: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+						Resource: taskStateEvents.logGroupArn,
+						Condition: {
+							ArnEquals: { 'aws:SourceArn': taskStateRule.attrArn },
+						},
+					},
+				],
+			}),
 		});
 
 		new GuCname(this, 'EcsDns', {

--- a/ecs-lifecycle-trace.mjs
+++ b/ecs-lifecycle-trace.mjs
@@ -1,0 +1,257 @@
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+// Builds a Jaeger trace for one ECS task from its task-state-change events in
+// CloudWatch Logs. Trace ID = the 32-hex ECS task ID; one span per lifecycle
+// state (PROVISIONING/PENDING/ACTIVATING/RUNNING/...). No pull/container detail.
+// Usage: node ecs-lifecycle-trace.mjs <taskId> [--flags]
+
+const arg = (name, fallback) => {
+	const i = process.argv.indexOf(`--${name}`);
+	return i !== -1 ? process.argv[i + 1] : fallback;
+};
+
+// Single positional argument: the ECS task id (also used as the trace id).
+const TASK_ID = process.argv
+	.slice(2)
+	.find((a, i, all) => !a.startsWith('--') && !all[i - 1]?.startsWith('--'));
+if (!TASK_ID) {
+	console.error('Usage: node ecs-lifecycle-trace.mjs <taskId> [--flags]');
+	process.exit(1);
+}
+
+const LOG_GROUP = arg('log-group', '/aws/events/cdk-playground-CODE-task-state');
+const PROFILE = arg('profile', 'deployTools');
+const REGION = arg('region', 'eu-west-1');
+const CLUSTER = arg(
+	'cluster',
+	'arn:aws:ecs:eu-west-1:095768028460:cluster/deploy-CODE-cdk-playground-ecs-cdkplaygroundEcsClusterF9ADCF3E-EavNroJI4xhl',
+);
+const SERVICE = arg(
+	'service',
+	'deploy-CODE-cdk-playground-ecs-EcsService81FC6EF6-clDl09kBIYOu',
+);
+const OTLP = arg('otlp', 'http://localhost:4319/v1/traces');
+const UI = arg('ui', 'http://localhost:16687');
+
+function fetchEvents(startMs, endMs) {
+	const events = [];
+	let token;
+	do {
+		const args = [
+			'logs',
+			'filter-log-events',
+			'--log-group-name',
+			LOG_GROUP,
+			'--start-time',
+			String(startMs),
+			'--end-time',
+			String(endMs),
+			'--profile',
+			PROFILE,
+			'--region',
+			REGION,
+			'--no-cli-pager',
+			'--output',
+			'json',
+		];
+		if (token) args.push('--next-token', token);
+		const raw = execFileSync('aws', args, { maxBuffer: 1e8 });
+		const page = JSON.parse(raw);
+		for (const e of page.events ?? []) events.push(JSON.parse(e.message));
+		token = page.nextToken;
+	} while (token);
+	return events;
+}
+
+const nanos = (iso) => String(Date.parse(iso) * 1_000_000);
+const spanId = () => randomBytes(8).toString('hex');
+const attr = (key, value) => ({ key, value: { stringValue: String(value) } });
+
+// describe-tasks milestone timestamps, attached to the root span as events ("logs").
+const MILESTONES = [
+	'createdAt',
+	'connectivityAt',
+	'pullStartedAt',
+	'pullStoppedAt',
+	'startedAt',
+];
+
+function fetchMilestones(taskId) {
+	try {
+		const raw = execFileSync(
+			'aws',
+			[
+				'ecs',
+				'describe-tasks',
+				'--cluster',
+				CLUSTER,
+				'--tasks',
+				taskId,
+				'--profile',
+				PROFILE,
+				'--region',
+				REGION,
+				'--no-cli-pager',
+				'--output',
+				'json',
+			],
+			{ maxBuffer: 1e8 },
+		);
+		const task = JSON.parse(raw).tasks?.[0] ?? {};
+		return Object.fromEntries(
+			MILESTONES.filter((k) => task[k]).map((k) => [k, task[k]]),
+		);
+	} catch {
+		return {}; // task aged out of describe-tasks
+	}
+}
+
+// Service events (task started / target registered / steady state) as span logs.
+function fetchServiceEvents() {
+	try {
+		const raw = execFileSync(
+			'aws',
+			[
+				'ecs',
+				'describe-services',
+				'--cluster',
+				CLUSTER,
+				'--services',
+				SERVICE,
+				'--profile',
+				PROFILE,
+				'--region',
+				REGION,
+				'--no-cli-pager',
+				'--query',
+				'services[0].events',
+				'--output',
+				'json',
+			],
+			{ maxBuffer: 1e8 },
+		);
+		return JSON.parse(raw) ?? [];
+	} catch {
+		return [];
+	}
+}
+
+function buildSpans(taskId, evts, milestones, serviceEvents) {
+	evts.sort(
+		(a, b) =>
+			Date.parse(a.detail.updatedAt) - Date.parse(b.detail.updatedAt) ||
+			a.detail.version - b.detail.version,
+	);
+	// Collapse consecutive events into distinct lifecycle-state phases.
+	const phases = [];
+	for (const e of evts) {
+		const state = e.detail.lastStatus;
+		if (!phases.length || phases.at(-1).state !== state) {
+			phases.push({
+				state,
+				start: e.detail.updatedAt,
+				desiredStatus: e.detail.desiredStatus,
+			});
+		}
+	}
+	const lastAt = evts.at(-1).detail.updatedAt;
+	phases.forEach((p, i) => {
+		p.end = i < phases.length - 1 ? phases[i + 1].start : lastAt;
+	});
+
+	// Service events (already filtered to the window) as span logs; extend the
+	// root span end to cover post-RUNNING ones (registration / steady state).
+	let rootEndMs = Date.parse(lastAt);
+	const svcLogs = serviceEvents.map((e) => ({
+		name: e.message,
+		timeUnixNano: nanos(e.createdAt),
+	}));
+	for (const e of svcLogs)
+		rootEndMs = Math.max(rootEndMs, Number(e.timeUnixNano) / 1_000_000);
+
+	const rootId = spanId();
+	const root = {
+		traceId: taskId,
+		spanId: rootId,
+		name: `ECS task ${taskId.slice(0, 8)} (${phases[0].state} → ${phases.at(-1).state})`,
+		kind: 1,
+		startTimeUnixNano: nanos(phases[0].start),
+		endTimeUnixNano: String(rootEndMs * 1_000_000),
+		attributes: [
+			attr('ecs.task.id', taskId),
+			attr('ecs.startedBy', evts.at(-1).detail.startedBy ?? '-'),
+			attr('ecs.group', evts.at(-1).detail.group ?? '-'),
+		],
+		events: [
+			...MILESTONES.filter((k) => milestones[k]).map((k) => ({
+				name: k,
+				timeUnixNano: nanos(milestones[k]),
+			})),
+			...svcLogs,
+		],
+	};
+
+	const children = phases.map((p) => ({
+		traceId: taskId,
+		spanId: spanId(),
+		parentSpanId: rootId,
+		name: p.state,
+		kind: 1,
+		startTimeUnixNano: nanos(p.start),
+		endTimeUnixNano: nanos(p.end),
+		attributes: [
+			attr('ecs.lastStatus', p.state),
+			attr('ecs.desiredStatus', p.desiredStatus),
+		],
+	}));
+
+	return [root, ...children];
+}
+
+const milestones = fetchMilestones(TASK_ID);
+if (!milestones.createdAt) {
+	console.error(
+		`describe-tasks returned no createdAt for ${TASK_ID} (task may have aged out).`,
+	);
+	process.exit(1);
+}
+
+// Window: [createdAt, createdAt + 60s], used for both the CloudWatch Logs
+// query and the service-event filter.
+const startMs = Date.parse(milestones.createdAt);
+const endMs = startMs + 60_000;
+
+// EventBridge writes CWL entries with second-precision timestamps, just below
+// the millisecond createdAt, so look back a few seconds to keep PROVISIONING.
+const events = fetchEvents(startMs - 5_000, endMs).filter((e) =>
+	e.detail?.taskArn?.endsWith(TASK_ID),
+);
+if (!events.length) {
+	console.error(`No task-state events for ${TASK_ID} in window.`);
+	process.exit(1);
+}
+
+const serviceEvents = fetchServiceEvents().filter((e) => {
+	const t = Date.parse(e.createdAt);
+	return t >= startMs && t <= endMs;
+});
+
+const spans = buildSpans(TASK_ID, events, milestones, serviceEvents);
+
+const body = {
+	resourceSpans: [
+		{
+			resource: { attributes: [attr('service.name', 'ECS Task lifecycle')] },
+			scopeSpans: [{ scope: { name: 'ecs-lifecycle' }, spans }],
+		},
+	],
+};
+
+const res = await fetch(OTLP, {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify(body),
+});
+console.log('POST', OTLP, '->', res.status, await res.text());
+console.log(`\ntrace: ${UI}/trace/${TASK_ID}`);

--- a/ecs-lifecycle-trace.mjs
+++ b/ecs-lifecycle-trace.mjs
@@ -5,6 +5,14 @@ import { randomBytes } from 'node:crypto';
 // CloudWatch Logs. Trace ID = the 32-hex ECS task ID; one span per lifecycle
 // state (PROVISIONING/PENDING/ACTIVATING/RUNNING/...). No pull/container detail.
 // Usage: node ecs-lifecycle-trace.mjs <taskId> [--flags]
+//
+// Jaeger container (all-in-one, in-memory; UI on 16687, OTLP HTTP on 4319):
+//   Start:   docker run -d --name ecs-timeline-jaeger \
+//              -p 16687:16686 -p 4319:4318 jaegertracing/jaeger:2.6.0
+//   Restart: docker restart ecs-timeline-jaeger   (clears all traces)
+//   Stop:    docker rm -f ecs-timeline-jaeger
+//   UI:      http://localhost:16687
+
 
 const arg = (name, fallback) => {
 	const i = process.argv.indexOf(`--${name}`);


### PR DESCRIPTION
Add an EventBridge rule that routes ECS Task State Change events for the cluster into a CloudWatch log group, so each task's per-state timeline (PROVISIONING -> ... -> STOPPED) can be reconstructed for scale-out latency analysis.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
