### PR TITLE
wip: Explicitly set ECS target group's logical ID

### DIFF
--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -339,7 +339,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
             "ContainerName": "cdk-playground",
             "ContainerPort": 9000,
             "TargetGroupArn": {
-              "Ref": "EcsTargetGroupCdkplayground55757231",
+              "Ref": "cdk-playground-ecs-target",
             },
           },
         ],
@@ -433,59 +433,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
         "ServiceNamespace": "ecs",
       },
       "Type": "AWS::ApplicationAutoScaling::ScalableTarget",
-    },
-    "EcsTargetGroupCdkplayground55757231": {
-      "Properties": {
-        "HealthCheckIntervalSeconds": 10,
-        "HealthCheckPath": "/healthcheck",
-        "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 5,
-        "HealthyThresholdCount": 5,
-        "Port": 9000,
-        "Protocol": "HTTP",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "cdk-playground",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "gu:riff-raff:project",
-            "Value": "devx::cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-        "TargetGroupAttributes": [
-          {
-            "Key": "deregistration_delay.timeout_seconds",
-            "Value": "30",
-          },
-          {
-            "Key": "stickiness.enabled",
-            "Value": "false",
-          },
-        ],
-        "TargetType": "ip",
-        "UnhealthyThresholdCount": 2,
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "EcsTaskDefinition63157ED3": {
       "Properties": {
@@ -1075,7 +1022,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
                 },
                 {
                   "TargetGroupArn": {
-                    "Ref": "EcsTargetGroupCdkplayground55757231",
+                    "Ref": "cdk-playground-ecs-target",
                   },
                   "Weight": 1,
                 },
@@ -1126,7 +1073,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
         "Actions": [
           {
             "TargetGroupArn": {
-              "Ref": "EcsTargetGroupCdkplayground55757231",
+              "Ref": "cdk-playground-ecs-target",
             },
             "Type": "forward",
           },
@@ -1443,6 +1390,59 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
           },
         ],
         "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "cdk-playground-ecs-target": {
+      "Properties": {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cdk-playground",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
         "UnhealthyThresholdCount": 2,
         "VpcId": {
           "Ref": "VpcId",

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -339,7 +339,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
             "ContainerName": "cdk-playground",
             "ContainerPort": 9000,
             "TargetGroupArn": {
-              "Ref": "cdk-playground-ecs-target",
+              "Ref": "cdkplaygroundecstarget",
             },
           },
         ],
@@ -1022,7 +1022,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
                 },
                 {
                   "TargetGroupArn": {
-                    "Ref": "cdk-playground-ecs-target",
+                    "Ref": "cdkplaygroundecstarget",
                   },
                   "Weight": 1,
                 },
@@ -1073,7 +1073,7 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
         "Actions": [
           {
             "TargetGroupArn": {
-              "Ref": "cdk-playground-ecs-target",
+              "Ref": "cdkplaygroundecstarget",
             },
             "Type": "forward",
           },
@@ -1397,7 +1397,34 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
-    "cdk-playground-ecs-target": {
+    "cdkplaygroundEcsClusterF9ADCF3E": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/cdk-playground",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "devx::cdk-playground",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "cdkplaygroundecstarget": {
       "Properties": {
         "HealthCheckIntervalSeconds": 10,
         "HealthCheckPath": "/healthcheck",
@@ -1449,33 +1476,6 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
-    },
-    "cdkplaygroundEcsClusterF9ADCF3E": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/cdk-playground",
-          },
-          {
-            "Key": "gu:riff-raff:project",
-            "Value": "devx::cdk-playground",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::ECS::Cluster",
     },
     "deployCODEcdkplaygroundCA0A63B1": {
       "DependsOn": [

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -40,7 +40,7 @@ export class CdkPlayground extends GuStack {
 
 		const ec2App = 'cdk-playground';
 
-		const { loadBalancer } = new GuLoadBalancedAppExperimental(this, {
+		const loadBalancedApp = new GuLoadBalancedAppExperimental(this, {
 			applicationPort: 9000,
 			app: ec2App,
 			access: { scope: AccessScope.PUBLIC },
@@ -91,7 +91,15 @@ export class CdkPlayground extends GuStack {
 			app: ec2App,
 			ttl: Duration.hours(1),
 			domainName: ec2AppDomainName,
-			resourceRecord: loadBalancer.loadBalancerDnsName,
+			resourceRecord: loadBalancedApp.loadBalancer.loadBalancerDnsName,
 		});
+
+		if (loadBalancedApp.targetGroups.ecs) {
+			this.overrideLogicalId(loadBalancedApp.targetGroups.ecs, {
+				logicalId: 'cdk-playground-ecs-target',
+				reason:
+					'Reverse engineering CloudFormation logic for naming a target group',
+			});
+		}
 	}
 }

--- a/cdk/lib/cdk-playground.ts
+++ b/cdk/lib/cdk-playground.ts
@@ -96,7 +96,7 @@ export class CdkPlayground extends GuStack {
 
 		if (loadBalancedApp.targetGroups.ecs) {
 			this.overrideLogicalId(loadBalancedApp.targetGroups.ecs, {
-				logicalId: 'cdk-playground-ecs-target',
+				logicalId: 'cdkplaygroundecstarget',
 				reason:
 					'Reverse engineering CloudFormation logic for naming a target group',
 			});


### PR DESCRIPTION
This is an attempt to understand the algorithm CloudFormation uses to name a target group when the Name property isn't in the template.

[After deployment](https://riffraff.gutools.co.uk/deployment/view/be3ff41f-b673-4635-bbf0-1233eff4a088), this yielded a target group named `deploy-cdkpl-1BBQJA5GCMDL`; previously it was something like `deploy-EcsTa-ABCDEFGHIJKLM`.