### PR TITLE
chore(deps): Update GuCDK from 64.3.0 to 64.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
         id: get-build-facts
 
   ci-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [facts]
     permissions:
       contents: read

--- a/build.sbt
+++ b/build.sbt
@@ -55,5 +55,5 @@ lazy val root = (project in file("."))
     ),
 
     dockerBaseImage := "amazoncorretto:21-alpine",
-    dockerBuildxPlatforms := Seq("linux/amd64")
+    dockerBuildxPlatforms := Seq("linux/arm64")
   )

--- a/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground-ecs.test.ts.snap
@@ -441,6 +441,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot for E
         "RequiresCompatibilities": [
           "FARGATE",
         ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+          "OperatingSystemFamily": "LINUX",
+        },
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
+++ b/cdk/lib/__snapshots__/cdk-playground.test.ts.snap
@@ -622,6 +622,10 @@ exports[`The cdk-playground infrastructure definition matches the snapshot 1`] =
         "RequiresCompatibilities": [
           "FARGATE",
         ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+          "OperatingSystemFamily": "LINUX",
+        },
         "Tags": [
           {
             "Key": "App",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@aws-sdk/client-auto-scaling": "3.1106.0",
 				"@aws-sdk/credential-providers": "3.1106.0",
-				"@guardian/cdk": "64.3.0",
+				"@guardian/cdk": "64.4.0",
 				"@guardian/eslint-config": "16.0.0",
 				"@guardian/prettier": "11.0.0",
 				"@types/aws-lambda": "8.10.162",
@@ -1703,9 +1703,9 @@
 			}
 		},
 		"node_modules/@guardian/cdk": {
-			"version": "64.3.0",
-			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-64.3.0.tgz",
-			"integrity": "sha512-Lfkac9pqB0meaVLLyg26c4+imgCyXeAaCJcWSUgm450REsn3xXkREsD4D7NqsPjGk7J0T9QrwljQZ93hTeNYow==",
+			"version": "64.4.0",
+			"resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-64.4.0.tgz",
+			"integrity": "sha512-0FeaWGMqIAc+KnQczWt92vpUWQig+uwCa8RtJSewfGjg0PkIg3YoUCjZ7MBgnbtpy4V2ReABfXn26v9ZsiXGdg==",
 			"dev": true,
 			"dependencies": {
 				"@aws-sdk/client-ec2": "^3.1087.0",
@@ -1714,7 +1714,7 @@
 				"chalk": "^4.1.2",
 				"codemaker": "^1.138.0",
 				"git-url-parse": "^16.0.1",
-				"js-yaml": "^4.3.0",
+				"js-yaml": "^4.3.1",
 				"read-pkg-up": "7.0.1",
 				"yargs": "^17.7.2"
 			},

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -18,7 +18,7 @@
 	"devDependencies": {
 		"@aws-sdk/client-auto-scaling": "3.1106.0",
 		"@aws-sdk/credential-providers": "3.1106.0",
-		"@guardian/cdk": "64.3.0",
+		"@guardian/cdk": "64.4.0",
 		"@guardian/eslint-config": "16.0.0",
 		"@guardian/prettier": "11.0.0",
 		"@types/aws-lambda": "8.10.162",


### PR DESCRIPTION
## What does this change?
This version uses ARM64 on ECS - https://github.com/guardian/cdk/releases/tag/v64.4.0. This change also updates CI to produce an ARM based image.

## How has this change been tested?
Successfully [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/7bedbd28-039d-4856-bab6-a5426f8357fd). When viewing the task in the AWS console, we now see:

<img width="271" height="120" alt="image" src="https://github.com/user-attachments/assets/70dad98b-d70c-4254-a6a1-eb9d9372dcff" />
